### PR TITLE
Hide error on empty folder

### DIFF
--- a/php-apache/docker-entrypoint.sh
+++ b/php-apache/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     \$config['log_driver'] = 'stdout';
     " > config/config.inc.php
 
-    for fn in `ls /var/roundcube/config/*.php`; do
+    for fn in `ls /var/roundcube/config/*.php 2>/dev/null || true`; do
       echo "include('$fn');" >> config/config.inc.php
     done
 

--- a/php-fpm/docker-entrypoint.sh
+++ b/php-fpm/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     \$config['log_driver'] = 'stdout';
     " > config/config.inc.php
 
-    for fn in `ls /var/roundcube/config/*.php`; do
+    for fn in `ls /var/roundcube/config/*.php 2>/dev/null || true`; do
       echo "include('$fn');" >> config/config.inc.php
     done
 


### PR DESCRIPTION
This is to suppress error message when the folder is empty:

`ls: cannot access /var/roundcube/config/*.php: No such file or directory`