### PR TITLE
Explicit PHP configuration and small bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The following env variables can be set to configure your Roundcube Docker instan
 
 `ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE` - File upload size limit; defaults to `5M`
 
+`ROUNDCUBEMAIL_PHP_MEMORY_LIMIT` - Memory limit for PHP; defaults to `64M`
+
 By default, the image will use a local SQLite database for storing user account metadata.
 It'll be created inside the `/var/www/html` directory and can be backed up from there. Please note that
 this option should not be used for production environments.

--- a/php-apache/Dockerfile
+++ b/php-apache/Dockerfile
@@ -48,6 +48,9 @@ RUN set -ex; \
 # enable mod_rewrite
 RUN a2enmod rewrite
 
+# use custom PHP settings
+COPY php.ini /usr/local/etc/php/conf.d/roundcube.ini
+
 # expose these volumes
 VOLUME /var/roundcube/config
 VOLUME /tmp/roundcube-temp

--- a/php-apache/docker-entrypoint.sh
+++ b/php-apache/docker-entrypoint.sh
@@ -87,6 +87,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   if [ ! -z "${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" ]; then
     sed -i -E "s/^(upload_max_filesize|post_max_size) *= *[0-9BKMG]+/\1=${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}/g" /usr/local/etc/php/conf.d/roundcube.ini
   fi
+  if [ ! -z "${ROUNDCUBEMAIL_PHP_MEMORY_LIMIT}" ]; then
+    sed -i -E "s/^memory_limit *= *[0-9BKMG]+/memory_limit=${ROUNDCUBEMAIL_PHP_MEMORY_LIMIT}/g" /usr/local/etc/php/conf.d/roundcube.ini
+  fi
 fi
 
 exec "$@"

--- a/php-apache/docker-entrypoint.sh
+++ b/php-apache/docker-entrypoint.sh
@@ -11,7 +11,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
       ( set -x; ls -A; sleep 10 )
     fi
     tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -
-    sed -i 's/mod_php5.c/mod_php7.c/' .htaccess
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
@@ -86,7 +85,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" ]; then
-    sed -i -E "s/(upload_max_filesize|post_max_size) +[0-9BKMG]+/\1 ${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}/g" $PWD/.htaccess
+    sed -i -E "s/^(upload_max_filesize|post_max_size) *= *[0-9BKMG]+/\1=${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}/g" /usr/local/etc/php/conf.d/roundcube.ini
   fi
 fi
 

--- a/php-apache/docker-entrypoint.sh
+++ b/php-apache/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
-  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ $ROUNDCUBEMAIL_DB_TYPE == "pgsql" ]; then
+  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=postgres}"
     : "${ROUNDCUBEMAIL_DB_USER:=${POSTGRES_ENV_POSTGRES_USER}}"
@@ -23,7 +23,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     : "${ROUNDCUBEMAIL_DSNW:=${ROUNDCUBEMAIL_DB_TYPE}://${ROUNDCUBEMAIL_DB_USER}:${ROUNDCUBEMAIL_DB_PASSWORD}@${ROUNDCUBEMAIL_DB_HOST}/${ROUNDCUBEMAIL_DB_NAME}}"
 
     /wait-for-it.sh ${ROUNDCUBEMAIL_DB_HOST}:5432 -t 30
-  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ] || [ $ROUNDCUBEMAIL_DB_TYPE == "mysql" ]; then
+  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "mysql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=mysql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=mysql}"
     : "${ROUNDCUBEMAIL_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"

--- a/php-apache/php.ini
+++ b/php-apache/php.ini
@@ -1,0 +1,10 @@
+memory_limit=64M
+display_errors=Off
+log_errors=On
+upload_max_filesize=5M
+post_max_size=6M
+zlib.output_compression=Off
+session.auto_start=Off
+session.gc_maxlifetime=21600
+session.gc_divisor=500
+session.gc_probability=1

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -45,6 +45,9 @@ RUN set -ex; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
+# use custom PHP settings
+COPY php.ini /usr/local/etc/php/conf.d/roundcube.ini
+
 # expose these volumes
 VOLUME /var/roundcube/config
 VOLUME /var/www/html

--- a/php-fpm/docker-entrypoint.sh
+++ b/php-fpm/docker-entrypoint.sh
@@ -87,6 +87,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   if [ ! -z "${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" ]; then
     sed -i -E "s/^(upload_max_filesize|post_max_size) *= *[0-9BKMG]+/\1=${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}/g" /usr/local/etc/php/conf.d/roundcube.ini
   fi
+  if [ ! -z "${ROUNDCUBEMAIL_PHP_MEMORY_LIMIT}" ]; then
+    sed -i -E "s/^memory_limit *= *[0-9BKMG]+/memory_limit=${ROUNDCUBEMAIL_PHP_MEMORY_LIMIT}/g" /usr/local/etc/php/conf.d/roundcube.ini
+  fi
 fi
 
 exec "$@"

--- a/php-fpm/docker-entrypoint.sh
+++ b/php-fpm/docker-entrypoint.sh
@@ -11,7 +11,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
       ( set -x; ls -A; sleep 10 )
     fi
     tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -
-    sed -i 's/mod_php5.c/mod_php7.c/' .htaccess
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
@@ -86,7 +85,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" ]; then
-    sed -i -E "s/(upload_max_filesize|post_max_size) +[0-9BKMG]+/\1 ${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}/g" $PWD/.htaccess
+    sed -i -E "s/^(upload_max_filesize|post_max_size) *= *[0-9BKMG]+/\1=${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}/g" /usr/local/etc/php/conf.d/roundcube.ini
   fi
 fi
 

--- a/php-fpm/docker-entrypoint.sh
+++ b/php-fpm/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
-  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ $ROUNDCUBEMAIL_DB_TYPE == "pgsql" ]; then
+  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=postgres}"
     : "${ROUNDCUBEMAIL_DB_USER:=${POSTGRES_ENV_POSTGRES_USER}}"
@@ -23,7 +23,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     : "${ROUNDCUBEMAIL_DSNW:=${ROUNDCUBEMAIL_DB_TYPE}://${ROUNDCUBEMAIL_DB_USER}:${ROUNDCUBEMAIL_DB_PASSWORD}@${ROUNDCUBEMAIL_DB_HOST}/${ROUNDCUBEMAIL_DB_NAME}}"
 
     /wait-for-it.sh ${ROUNDCUBEMAIL_DB_HOST}:5432 -t 30
-  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ] || [ $ROUNDCUBEMAIL_DB_TYPE == "mysql" ]; then
+  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "mysql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=mysql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=mysql}"
     : "${ROUNDCUBEMAIL_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"

--- a/php-fpm/php.ini
+++ b/php-fpm/php.ini
@@ -1,0 +1,10 @@
+memory_limit=64M
+display_errors=Off
+log_errors=On
+upload_max_filesize=5M
+post_max_size=6M
+zlib.output_compression=Off
+session.auto_start=Off
+session.gc_maxlifetime=21600
+session.gc_divisor=500
+session.gc_probability=1


### PR DESCRIPTION
Hello,

https://github.com/roundcube/roundcubemail/commit/c0b902521568fc45c689dd74d13b4e81edb30116 removes PHP settings from the provided .htaccess file. In this PR, a php.ini is provided instead.

Furthermore, the PHP memory limit can be configured via an environment variable and a small bugfix (invalid syntax in entrypoint script) is included.