### PR TITLE
Fix error on startup for empty ROUNDCUBEMAIL_DB_TYPE

### DIFF
--- a/php-apache/docker-entrypoint.sh
+++ b/php-apache/docker-entrypoint.sh
@@ -15,7 +15,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
-  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ $ROUNDCUBEMAIL_DB_TYPE == "pgsql" ]; then
+  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=postgres}"
     : "${ROUNDCUBEMAIL_DB_USER:=${POSTGRES_ENV_POSTGRES_USER}}"
@@ -24,7 +24,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     : "${ROUNDCUBEMAIL_DSNW:=${ROUNDCUBEMAIL_DB_TYPE}://${ROUNDCUBEMAIL_DB_USER}:${ROUNDCUBEMAIL_DB_PASSWORD}@${ROUNDCUBEMAIL_DB_HOST}/${ROUNDCUBEMAIL_DB_NAME}}"
 
     /wait-for-it.sh ${ROUNDCUBEMAIL_DB_HOST}:5432 -t 30
-  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ] || [ $ROUNDCUBEMAIL_DB_TYPE == "mysql" ]; then
+  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "mysql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=mysql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=mysql}"
     : "${ROUNDCUBEMAIL_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"

--- a/php-fpm/docker-entrypoint.sh
+++ b/php-fpm/docker-entrypoint.sh
@@ -15,7 +15,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
-  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ $ROUNDCUBEMAIL_DB_TYPE == "pgsql" ]; then
+  if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=postgres}"
     : "${ROUNDCUBEMAIL_DB_USER:=${POSTGRES_ENV_POSTGRES_USER}}"
@@ -24,7 +24,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     : "${ROUNDCUBEMAIL_DSNW:=${ROUNDCUBEMAIL_DB_TYPE}://${ROUNDCUBEMAIL_DB_USER}:${ROUNDCUBEMAIL_DB_PASSWORD}@${ROUNDCUBEMAIL_DB_HOST}/${ROUNDCUBEMAIL_DB_NAME}}"
 
     /wait-for-it.sh ${ROUNDCUBEMAIL_DB_HOST}:5432 -t 30
-  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ] || [ $ROUNDCUBEMAIL_DB_TYPE == "mysql" ]; then
+  elif [ ! -z "${!MYSQL_ENV_MYSQL_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "mysql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=mysql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=mysql}"
     : "${ROUNDCUBEMAIL_DB_USER:=${MYSQL_ENV_MYSQL_USER:-root}}"


### PR DESCRIPTION
Add quotation marks to avoid syntax errors when ROUNDCUBEMAIL_DB_TYPE is not set or empty.