### PR TITLE
Fix: Recommended PHP settings not in .htaccess anymore

### DIFF
--- a/php-apache/Dockerfile
+++ b/php-apache/Dockerfile
@@ -48,6 +48,9 @@ RUN set -ex; \
 # enable mod_rewrite
 RUN a2enmod rewrite
 
+# use custom PHP settings
+COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
+
 # expose these volumes
 VOLUME /var/roundcube/config
 VOLUME /tmp/roundcube-temp

--- a/php-apache/docker-entrypoint.sh
+++ b/php-apache/docker-entrypoint.sh
@@ -11,7 +11,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
       ( set -x; ls -A; sleep 10 )
     fi
     tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -
-    sed -i 's/mod_php5.c/mod_php7.c/' .htaccess
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
@@ -86,7 +85,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" ]; then
-    sed -i -E "s/(upload_max_filesize|post_max_size) +[0-9BKMG]+/\1 ${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}/g" $PWD/.htaccess
+    echo "upload_max_filesize=${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/roundcube-override.ini
+    echo "post_max_size=${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/roundcube-override.ini
   fi
 fi
 

--- a/php-apache/php.ini
+++ b/php-apache/php.ini
@@ -1,0 +1,10 @@
+memory_limit=64M
+display_errors=Off
+log_errors=On
+upload_max_filesize=5M
+post_max_size=6M
+zlib.output_compression=Off
+session.auto_start=Off
+session.gc_maxlifetime=21600
+session.gc_divisor=500
+session.gc_probability=1

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -45,6 +45,9 @@ RUN set -ex; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
 	rm -rf /var/lib/apt/lists/*
 
+# use custom PHP settings
+COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
+
 # expose these volumes
 VOLUME /var/roundcube/config
 VOLUME /var/www/html

--- a/php-fpm/docker-entrypoint.sh
+++ b/php-fpm/docker-entrypoint.sh
@@ -11,7 +11,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
       ( set -x; ls -A; sleep 10 )
     fi
     tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -
-    sed -i 's/mod_php5.c/mod_php7.c/' .htaccess
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $PWD"
   fi
 
@@ -86,7 +85,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" ]; then
-    sed -i -E "s/(upload_max_filesize|post_max_size) +[0-9BKMG]+/\1 ${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}/g" $PWD/.htaccess
+    echo "upload_max_filesize=${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/roundcube-override.ini
+    echo "post_max_size=${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" >> /usr/local/etc/php/conf.d/roundcube-override.ini
   fi
 fi
 

--- a/php-fpm/php.ini
+++ b/php-fpm/php.ini
@@ -1,0 +1,10 @@
+memory_limit=64M
+display_errors=Off
+log_errors=On
+upload_max_filesize=5M
+post_max_size=6M
+zlib.output_compression=Off
+session.auto_start=Off
+session.gc_maxlifetime=21600
+session.gc_divisor=500
+session.gc_probability=1


### PR DESCRIPTION
https://github.com/roundcube/roundcubemail/commit/c0b902521568fc45c689dd74d13b4e81edb30116 removed the recommended Roundcube PHP defaults from `.htaccess`, so we should configure PHP ourselves as recommended in the Roundcube documentation.

This PR adds a `php.ini` file with the recommended settings. It is deployed to `/usr/local/etc/php/conf.d/roundcube-defaults.ini`, the existing environment variable `ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE` is supported via a file `/usr/local/etc/php/conf.d/roundcube-override.ini` (created only if needed).