### PR TITLE
Extend readme with customization of PHP settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ docker run -v ./config/:/var/roundcube/config/ -d roundcube/roundcubemail
 
 Check the Roundcube Webmail wiki for a reference of [Roundcube config options](https://github.com/roundcube/roundcubemail/wiki/Configuration).
 
+Customized PHP settings can be implemented by mounting a configuration file to `/usr/local/etc/php/conf.d/zzz_roundcube-custom.ini`.
+For example, it may be used to increase the PHP memory limit (`memory_limit=128M`).
+
 ## Building a Docker image
 
 Use the `Dockerfile` in this repository to build your own Docker image.


### PR DESCRIPTION
This PR adds a short paragraph regarding customization of PHP settings to the readme (in the "Advanced configuration" section).
In particular when users increase the upload filesize it may make sense to increase the memory limit as well, so this is used as an example.