### PR TITLE
Use pgp.mit.edu as fallback keyserver if necessary

### DIFF
--- a/php-apache/Dockerfile
+++ b/php-apache/Dockerfile
@@ -63,7 +63,8 @@ RUN set -ex; \
 	curl -o roundcubemail.tar.gz -SL https://github.com/roundcube/roundcubemail/releases/download/${ROUNDCUBEMAIL_VERSION}/roundcubemail-${ROUNDCUBEMAIL_VERSION}-complete.tar.gz; \
 	curl -o roundcubemail.tar.gz.asc -SL https://github.com/roundcube/roundcubemail/releases/download/${ROUNDCUBEMAIL_VERSION}/roundcubemail-${ROUNDCUBEMAIL_VERSION}-complete.tar.gz.asc; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
+	# ha.pool.sks-keyservers.net seems to be unreliable, use pgp.mit.edu as fallback
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5 || gpg --keyserver pgp.mit.edu --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
 	gpg --batch --verify roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	tar -xzf roundcubemail.tar.gz -C /usr/src/; \
 	gpgconf --kill all; \

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -60,7 +60,8 @@ RUN set -ex; \
 	curl -o roundcubemail.tar.gz -SL https://github.com/roundcube/roundcubemail/releases/download/${ROUNDCUBEMAIL_VERSION}/roundcubemail-${ROUNDCUBEMAIL_VERSION}-complete.tar.gz; \
 	curl -o roundcubemail.tar.gz.asc -SL https://github.com/roundcube/roundcubemail/releases/download/${ROUNDCUBEMAIL_VERSION}/roundcubemail-${ROUNDCUBEMAIL_VERSION}-complete.tar.gz.asc; \
 	export GNUPGHOME="$(mktemp -d)"; \
-	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
+	# ha.pool.sks-keyservers.net seems to be unreliable, use pgp.mit.edu as fallback
+	gpg --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5 || gpg --keyserver pgp.mit.edu --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
 	gpg --batch --verify roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	tar -xzf roundcubemail.tar.gz -C /usr/src/; \
 	gpgconf --kill all; \


### PR DESCRIPTION
I had the problem that building the image does not work about every second time. The reason is that the round robin from `ha.pool.sks-keyservers.net` sometimes provides servers that time out.

So, in this PR, I introduce a fallback to `pgp.mit.edu`. Note that many other projects already have similar workarounds.