### PR TITLE
Upgrade to version 1.3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ notifications:
   email: false
 
 env: # Environments
-    - VERSION=1.3.6 VARIANT=fpm
-    - VERSION=1.3.6 VARIANT=apache
+    - VERSION=1.3.7 VARIANT=fpm
+    - VERSION=1.3.7 VARIANT=apache

--- a/php-apache/Dockerfile
+++ b/php-apache/Dockerfile
@@ -56,7 +56,7 @@ VOLUME /var/roundcube/config
 VOLUME /tmp/roundcube-temp
 
 # Define Roundcubemail version
-ENV ROUNDCUBEMAIL_VERSION 1.3.6
+ENV ROUNDCUBEMAIL_VERSION 1.3.7
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -53,7 +53,7 @@ VOLUME /var/roundcube/config
 VOLUME /var/www/html
 
 # Define Roundcubemail version
-ENV ROUNDCUBEMAIL_VERSION 1.3.6
+ENV ROUNDCUBEMAIL_VERSION 1.3.7
 
 # Download package and extract to web volume
 RUN set -ex; \


### PR DESCRIPTION
This PR updates the Roundcube version number to 1.3.7. I'm using this for a few days now and saw no problem (except https://github.com/roundcube/roundcubemail/issues/6374, but that's not critical).