### PR TITLE
Better defaults for smtp settings, fixes #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,20 @@
 The simplest method is to run the official image:
 
 ```
-docker run -e ROUNDCUBEMAIL_DEFAULT_HOST=mail -d roundcube/roundcubemail
+docker run -e ROUNDCUBEMAIL_DEFAULT_HOST=tls://mail -e ROUNDCUBEMAIL_SMTP_SERVER=tls://mail -d roundcube/roundcubemail
 ```
+
+where `mail` should be replaced by your host name for the IMAP and SMTP server.
 
 ## Configuration/Environment Variables
 
 The following env variables can be set to configure your Roundcube Docker instance:
 
-`ROUNDCUBEMAIL_DEFAULT_HOST` - Hostname of the IMAP server to connect to
+`ROUNDCUBEMAIL_DEFAULT_HOST` - Hostname of the IMAP server to connect to, use `tls://` prefix for STARTTLS
 
 `ROUNDCUBEMAIL_DEFAULT_PORT` - IMAP port number; defaults to `143`
 
-`ROUNDCUBEMAIL_SMTP_SERVER` - Hostname of the SMTP server to send mails
+`ROUNDCUBEMAIL_SMTP_SERVER` - Hostname of the SMTP server to send mails, use `tls://` prefix for STARTTLS
 
 `ROUNDCUBEMAIL_SMTP_PORT`  - SMTP port number; defaults to `587`
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The simplest method is to run the official image:
 
 ```
-docker run -e ROUNDCUBEMAIL_DEFAULT_HOST=tls://mail -e ROUNDCUBEMAIL_SMTP_SERVER=tls://mail -d roundcube/roundcubemail
+docker run -e ROUNDCUBEMAIL_DEFAULT_HOST=mail -e ROUNDCUBEMAIL_SMTP_SERVER=mail -d roundcube/roundcubemail
 ```
 
 where `mail` should be replaced by your host name for the IMAP and SMTP server.

--- a/php-apache/docker-entrypoint.sh
+++ b/php-apache/docker-entrypoint.sh
@@ -67,6 +67,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     \$config['default_port'] = '${ROUNDCUBEMAIL_DEFAULT_PORT}';
     \$config['smtp_server'] = '${ROUNDCUBEMAIL_SMTP_SERVER}';
     \$config['smtp_port'] = '${ROUNDCUBEMAIL_SMTP_PORT}';
+    \$config['smtp_user'] = '%u';
+    \$config['smtp_pass'] = '%p';
     \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
     \$config['plugins'] = ['${ROUNDCUBEMAIL_PLUGINS_PHP}'];
     \$config['zipdownload_selection'] = true;

--- a/php-fpm/docker-entrypoint.sh
+++ b/php-fpm/docker-entrypoint.sh
@@ -67,6 +67,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     \$config['default_port'] = '${ROUNDCUBEMAIL_DEFAULT_PORT}';
     \$config['smtp_server'] = '${ROUNDCUBEMAIL_SMTP_SERVER}';
     \$config['smtp_port'] = '${ROUNDCUBEMAIL_SMTP_PORT}';
+    \$config['smtp_user'] = '%u';
+    \$config['smtp_pass'] = '%p';
     \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
     \$config['plugins'] = ['${ROUNDCUBEMAIL_PLUGINS_PHP}'];
     \$config['zipdownload_selection'] = true;


### PR DESCRIPTION
This PR contains the most simple implementation for #24: hardcode the defaults, no environment variable.

I tried it locally, it works for me. I modified the readme because the SMTP server has to be specified separately (otherwise it is localhost). And I added `tls://` to the example because (hopefully) SMTP servers will require TLS before they accept SMTP AUTH. Anyway, activating encryption should always be a good idea.