### PR TITLE
Always create and chown ROUNDCUBEMAIL_TEMP_DIR

### DIFF
--- a/php-apache/docker-entrypoint.sh
+++ b/php-apache/docker-entrypoint.sh
@@ -56,7 +56,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
   if [ ! -e config/config.inc.php ]; then
     ROUNDCUBEMAIL_PLUGINS_PHP=`echo "${ROUNDCUBEMAIL_PLUGINS}" | sed -E "s/[, ]+/', '/g"`
-    mkdir -p ${ROUNDCUBEMAIL_TEMP_DIR} && chown www-data ${ROUNDCUBEMAIL_TEMP_DIR}
     touch config/config.inc.php
 
     echo "Write config to $PWD/config/config.inc.php"
@@ -84,6 +83,10 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   else
     echo "WARNING: $PWD/config/config.inc.php already exists."
     echo "ROUNDCUBEMAIL_* environment variables have been ignored."
+  fi
+
+  if [ ! -z "${ROUNDCUBEMAIL_TEMP_DIR}" ]; then
+    mkdir -p ${ROUNDCUBEMAIL_TEMP_DIR} && chown www-data ${ROUNDCUBEMAIL_TEMP_DIR}
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE}" ]; then


### PR DESCRIPTION
Create and chown `ROUNDCUBEMAIL_TEMP_DIR` although `config.inc.php` exists.
Reasoning:
1. A new container with `config.inc.php` will not have the default temp folder what will lead to errors even when `$config['temp_dir']` is left at its default value. If the `config.inc.php` specifies a custom one, the admin should now what he is doing and can set `ROUNDCUBEMAIL_TEMP_DIR` accordingly.
2. In a multi server setup a bind mount to `/tmp/roundcube-temp` will get the correct permissions set which will often be `root:root` with `0755` initially.