### PR TITLE
#82 Added tzdata package

### DIFF
--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -6,7 +6,8 @@ RUN set -ex; \
 	\
 	apk add --no-cache \
 		bash \
-		coreutils
+		coreutils \
+		tzdata
 
 RUN set -ex; \
 	\


### PR DESCRIPTION
Added tzdata package so that the TZ env variable is handled correctly.

```
docker run --rm -it -e "TZ=Europe/Luxembourg" 65e9ecffb89e date
Fri Mar 27 20:57:33 CET 2020
docker run --rm -it -e "TZ=Europe/London" 65e9ecffb89e date
Fri Mar 27 19:58:49 GMT 2020
```

Fixes #82 