### PR TITLE
www data owner of files

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -75,7 +75,7 @@ RUN set -ex; \
 	tar -xf roundcubemail.tar.gz -C /usr/src/roundcubemail --strip-components=1; \
 	rm -r "$GNUPGHOME" roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	rm -rf /usr/src/roundcubemail/installer; \
-	chown -R www-data:www-data /usr/src/roundcubemail/
+	chown -R www-data:www-data /usr/src/roundcubemail/logs
 
 # include the wait-for-it.sh script
 RUN curl -fL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /wait-for-it.sh && chmod +x /wait-for-it.sh

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -70,12 +70,12 @@ RUN set -ex; \
 	# ha.pool.sks-keyservers.net seems to be unreliable, use pgp.mit.edu as fallback
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5 || gpg --batch --keyserver pgp.mit.edu --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
 	gpg --batch --verify roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
-	tar -xf roundcubemail.tar.gz -C /usr/src/; \
 	gpgconf --kill all; \
+  mkdir /usr/src/roundcubemail; \
+	tar -xf roundcubemail.tar.gz -C /usr/src/roundcubemail --strip-components=1; \
 	rm -r "$GNUPGHOME" roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
-	# upstream tarballs include ./roundcubemail-${ROUNDCUBEMAIL_VERSION}/ so this gives us /usr/src/roundcubemail-${ROUNDCUBEMAIL_VERSION}
-	mv /usr/src/roundcubemail-${ROUNDCUBEMAIL_VERSION} /usr/src/roundcubemail; \
-	rm -rf /usr/src/roundcubemail/installer
+	rm -rf /usr/src/roundcubemail/installer; \
+  chown -R www-data:www-data /usr/src/roundcubemail/
 
 # include the wait-for-it.sh script
 RUN curl -fL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /wait-for-it.sh && chmod +x /wait-for-it.sh

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -71,11 +71,11 @@ RUN set -ex; \
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5 || gpg --batch --keyserver pgp.mit.edu --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
 	gpg --batch --verify roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	gpgconf --kill all; \
-  mkdir /usr/src/roundcubemail; \
+	mkdir /usr/src/roundcubemail; \
 	tar -xf roundcubemail.tar.gz -C /usr/src/roundcubemail --strip-components=1; \
 	rm -r "$GNUPGHOME" roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	rm -rf /usr/src/roundcubemail/installer; \
-  chown -R www-data:www-data /usr/src/roundcubemail/
+	chown -R www-data:www-data /usr/src/roundcubemail/
 
 # include the wait-for-it.sh script
 RUN curl -fL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /wait-for-it.sh && chmod +x /wait-for-it.sh

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -70,7 +70,7 @@ RUN set -ex; \
 	tar -xf roundcubemail.tar.gz -C /usr/src/roundcubemail --strip-components=1; \
 	rm -r "$GNUPGHOME" roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	rm -rf /usr/src/roundcubemail/installer; \
-	chown -R www-data:www-data /usr/src/roundcubemail/; \
+	chown -R www-data:www-data /usr/src/roundcubemail/logs; \
 	apk del .fetch-deps
 
 # include the wait-for-it.sh script

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -65,12 +65,12 @@ RUN set -ex; \
 	# ha.pool.sks-keyservers.net seems to be unreliable, use pgp.mit.edu as fallback
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5 || gpg --batch --keyserver pgp.mit.edu --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
 	gpg --batch --verify roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
-	tar -xf roundcubemail.tar.gz -C /usr/src/; \
 	gpgconf --kill all; \
+	mkdir /usr/src/roundcubemail; \
+	tar -xf roundcubemail.tar.gz -C /usr/src/roundcubemail --strip-components=1; \
 	rm -r "$GNUPGHOME" roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
-	# upstream tarballs include ./roundcubemail-${ROUNDCUBEMAIL_VERSION}/ so this gives us /usr/src/roundcubemail-${ROUNDCUBEMAIL_VERSION}
-	mv /usr/src/roundcubemail-${ROUNDCUBEMAIL_VERSION} /usr/src/roundcubemail; \
 	rm -rf /usr/src/roundcubemail/installer; \
+	chown -R www-data:www-data /usr/src/roundcubemail/; \
 	apk del .fetch-deps
 
 # include the wait-for-it.sh script

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -68,12 +68,12 @@ RUN set -ex; \
 	# ha.pool.sks-keyservers.net seems to be unreliable, use pgp.mit.edu as fallback
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5 || gpg --batch --keyserver pgp.mit.edu --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
 	gpg --batch --verify roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
-	tar -xf roundcubemail.tar.gz -C /usr/src/; \
 	gpgconf --kill all; \
+  mkdir /usr/src/roundcubemail; \
+	tar -xf roundcubemail.tar.gz -C /usr/src/roundcubemail --strip-components=1; \
 	rm -r "$GNUPGHOME" roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
-	# upstream tarballs include ./roundcubemail-${ROUNDCUBEMAIL_VERSION}/ so this gives us /usr/src/roundcubemail-${ROUNDCUBEMAIL_VERSION}
-	mv /usr/src/roundcubemail-${ROUNDCUBEMAIL_VERSION} /usr/src/roundcubemail; \
-	rm -rf /usr/src/roundcubemail/installer
+	rm -rf /usr/src/roundcubemail/installer; \
+  chown -R www-data:www-data /usr/src/roundcubemail/
 
 # include the wait-for-it.sh script
 RUN curl -fL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /wait-for-it.sh && chmod +x /wait-for-it.sh

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -73,7 +73,7 @@ RUN set -ex; \
 	tar -xf roundcubemail.tar.gz -C /usr/src/roundcubemail --strip-components=1; \
 	rm -r "$GNUPGHOME" roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	rm -rf /usr/src/roundcubemail/installer; \
-	chown -R www-data:www-data /usr/src/roundcubemail/
+	chown -R www-data:www-data /usr/src/roundcubemail/logs
 
 # include the wait-for-it.sh script
 RUN curl -fL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /wait-for-it.sh && chmod +x /wait-for-it.sh

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -69,11 +69,11 @@ RUN set -ex; \
 	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5 || gpg --batch --keyserver pgp.mit.edu --recv-keys F3E4C04BB3DB5D4215C45F7F5AB2BAA141C4F7D5; \
 	gpg --batch --verify roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	gpgconf --kill all; \
-  mkdir /usr/src/roundcubemail; \
+	mkdir /usr/src/roundcubemail; \
 	tar -xf roundcubemail.tar.gz -C /usr/src/roundcubemail --strip-components=1; \
 	rm -r "$GNUPGHOME" roundcubemail.tar.gz.asc roundcubemail.tar.gz; \
 	rm -rf /usr/src/roundcubemail/installer; \
-  chown -R www-data:www-data /usr/src/roundcubemail/
+	chown -R www-data:www-data /usr/src/roundcubemail/
 
 # include the wait-for-it.sh script
 RUN curl -fL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh > /wait-for-it.sh && chmod +x /wait-for-it.sh


### PR DESCRIPTION
Now all source files belong correctly to www-data:www-data

```
docker run --rm -it 08a7c56d6585  bash -c "tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -; ls -la; pwd"
total 396
drwxr-xr-x 12 www-data www-data   4096 Mar 27 21:37 .
drwxr-xr-x  1 root     root       4096 Feb 26 11:59 ..
-rw-r--r--  1 www-data www-data   2603 Feb 19 20:55 .htaccess
-rw-r--r--  1 www-data www-data 179346 Feb 19 20:55 CHANGELOG
-rw-r--r--  1 www-data www-data  12693 Feb 19 20:55 INSTALL
-rw-r--r--  1 www-data www-data  35147 Feb 19 20:55 LICENSE
-rw-r--r--  1 www-data www-data   3810 Feb 19 20:55 README.md
drwxr-xr-x  7 www-data www-data   4096 Feb 19 20:55 SQL
-rw-r--r--  1 www-data www-data   4148 Feb 19 20:55 UPGRADING
drwxr-xr-x  2 www-data www-data   4096 Mar 27 21:37 bin
-rw-r--r--  1 www-data www-data    908 Feb 19 20:55 composer.json
-rw-r--r--  1 www-data www-data    940 Feb 19 20:55 composer.json-dist
-rw-r--r--  1 www-data www-data  78672 Feb 19 20:56 composer.lock
drwxr-xr-x  2 www-data www-data   4096 Mar 27 21:37 config
-rw-r--r--  1 www-data www-data  12731 Feb 19 20:55 index.php
drwxr-xr-x  2 www-data www-data   4096 Mar 27 21:37 logs
drwxr-xr-x 35 www-data www-data   4096 Mar 27 21:37 plugins
drwxr-xr-x  8 www-data www-data   4096 Mar 27 21:37 program
drwxr-xr-x  3 www-data www-data   4096 Mar 27 21:37 public_html
drwxr-xr-x  5 www-data www-data   4096 Mar 27 21:37 skins
drwxr-xr-x  2 www-data www-data   4096 Mar 27 21:37 temp
drwxr-xr-x  9 www-data www-data   4096 Mar 27 21:37 vendor
```

Fixes #84 