### PR TITLE
Fix path to the sqlite.db

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The following env variables can be set to configure your Roundcube Docker instan
 `ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE` - File upload size limit; defaults to `5M`
 
 By default, the image will use a local SQLite database for storing user account metadata.
-It'll be created inside the `/var/www/html` directory and can be backed up from there. Please note that
+It'll be created inside the `/var/roundcube/db` directory and can be backed up from there. Please note that
 this option should not be used for production environments.
 
 ### Connect to a Database


### PR DESCRIPTION
Tested with the latest image (on Fedora 32 with podman), the default sqlite file is created under /var/roundcube/db, not /var/www/html.