### PR TITLE
enable opcache

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex; \
 		zip \
 	; \
 	pecl install imagick; \
-	docker-php-ext-enable imagick; \
+	docker-php-ext-enable imagick opcache; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -38,7 +38,7 @@ RUN set -ex; \
 		zip \
 	; \
 	pecl install imagick; \
-	docker-php-ext-enable imagick; \
+	docker-php-ext-enable imagick opcache; \
 	\
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex; \
 		zip \
 	; \
 	pecl install imagick; \
-	docker-php-ext-enable imagick; \
+	docker-php-ext-enable imagick opcache; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \

--- a/templates/Dockerfile-alpine.templ
+++ b/templates/Dockerfile-alpine.templ
@@ -38,7 +38,7 @@ RUN set -ex; \
 		zip \
 	; \
 	pecl install imagick; \
-	docker-php-ext-enable imagick; \
+	docker-php-ext-enable imagick opcache; \
 	\
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -32,7 +32,7 @@ RUN set -ex; \
 		zip \
 	; \
 	pecl install imagick; \
-	docker-php-ext-enable imagick; \
+	docker-php-ext-enable imagick opcache; \
 	\
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
 	apt-mark auto '.*' > /dev/null; \


### PR DESCRIPTION
I run the apache image and noticed the opcache module is installed but not used, this enables it. I didn't do many benchmarks but clicking into some folders and monitoring the firefox network tab showed response times generally went from 60-70ms to 30-40ms on my server. This could further be improved by disabling the file update checks:
https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.validate-timestamps
If we disable the file update checks we might need a config option to enable it again for development purposes. Let me know what you think.