### PR TITLE
Add "chmod +x docker-entrypoint.sh" to Dockerfiles

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -110,5 +110,8 @@ COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 
 COPY docker-entrypoint.sh /
 
+# Ensure docker-entrypoint.sh is executable
+RUN chmod +x /docker-entrypoint.sh
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -102,5 +102,8 @@ COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 
 COPY docker-entrypoint.sh /
 
+# Ensure docker-entrypoint.sh is executable
+RUN chmod +x /docker-entrypoint.sh
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["php-fpm"]

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -109,5 +109,8 @@ COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 
 COPY docker-entrypoint.sh /
 
+# Ensure docker-entrypoint.sh is executable
+RUN chmod +x /docker-entrypoint.sh
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["php-fpm"]


### PR DESCRIPTION
In case someone wants to build this for themselves, the normal rout is of course that this person uses `git clone https://github.com/roundcube/roundcubemail-docker.git` & gets the repository, and then builds whatever image they want.

In my case, I opted to `wget` the raw files for the Apache version as I thought that was easier & potentially faster than downloading the repo (I didn't see that it was so small effectively :-).

This meant docker-entrypoint.sh didn't have +x permissions, which in my case meant that the docker build works fine, but then starting the image gives 'random' errors (I use Portainer which can be a little unclear at times). I thought the issue was with the fact that I am using armv7 (raspberry pi), but it was simply the file permission.

Fix in this PR:
Add a `chmod +x /docker-entrypoint.sh` to all three Dockerfiles In case the user of this repository for whatever reason has not set a +x modifier on docker-entrypoint.sh, this prevents 'random' errors.