### PR TITLE
added COMPOSER_ALLOW_SUPERUSER env var to dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,12 @@ RUN set -ex; \
 
 RUN composer \
     --working-dir=/usr/src/roundcubemail/ \
+    --prefer-dist \
     --prefer-stable \
     --update-no-dev \
     --no-interaction \
     --optimize-autoloader \
     require \
-        weird-birds/thunderbird_labels \
-  ;
+        johndoh/contextmenu \
+  ; \
 ```

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ For instance, you could extend this image to add composer and install requiremen
 ```Dockerfile
 FROM roundcube/roundcubemail:latest
 
+# COMPOSER_ALLOW_SUPERUSER is needed to run plugins when using a container
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
 RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
@@ -158,9 +161,7 @@ RUN set -ex; \
     ; \
     \
 
-# COMPOSER_ALLOW_SUPERUSER is needed to run plugins when using a container
-RUN export COMPOSER_ALLOW_SUPERUSER=1 && \
-  composer \
+RUN composer \
     --working-dir=/usr/src/roundcubemail/ \
     --prefer-stable \
     --update-no-dev \

--- a/README.md
+++ b/README.md
@@ -157,14 +157,13 @@ RUN set -ex; \
         git \
     ; \
     \
-    composer \
+RUN COMPOSER_ALLOW_SUPERUSER=1 composer \
         --working-dir=/usr/src/roundcubemail/ \
-        --prefer-dist \
         --prefer-stable \
         --update-no-dev \
         --no-interaction \
         --optimize-autoloader \
         require \
-            johndoh/contextmenu \
-    ; \
+            weird-birds/thunderbird_labels \
+    ;
 ```

--- a/README.md
+++ b/README.md
@@ -157,7 +157,11 @@ RUN set -ex; \
         git \
     ; \
     \
-RUN COMPOSER_ALLOW_SUPERUSER=1 composer \
+
+# needed to run plugins when using containers
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
+RUN composer \
         --working-dir=/usr/src/roundcubemail/ \
         --prefer-stable \
         --update-no-dev \

--- a/README.md
+++ b/README.md
@@ -158,16 +158,15 @@ RUN set -ex; \
     ; \
     \
 
-# needed to run plugins when using containers
-ENV COMPOSER_ALLOW_SUPERUSER=1
-
-RUN composer \
-        --working-dir=/usr/src/roundcubemail/ \
-        --prefer-stable \
-        --update-no-dev \
-        --no-interaction \
-        --optimize-autoloader \
-        require \
-            weird-birds/thunderbird_labels \
-    ;
+# COMPOSER_ALLOW_SUPERUSER is needed to run plugins when using a container
+RUN export COMPOSER_ALLOW_SUPERUSER=1 && \
+  composer \
+    --working-dir=/usr/src/roundcubemail/ \
+    --prefer-stable \
+    --update-no-dev \
+    --no-interaction \
+    --optimize-autoloader \
+    require \
+        weird-birds/thunderbird_labels \
+  ;
 ```

--- a/README.md
+++ b/README.md
@@ -160,15 +160,14 @@ RUN set -ex; \
         git \
     ; \
     \
-
-RUN composer \
-    --working-dir=/usr/src/roundcubemail/ \
-    --prefer-dist \
-    --prefer-stable \
-    --update-no-dev \
-    --no-interaction \
-    --optimize-autoloader \
-    require \
-        johndoh/contextmenu \
-  ; \
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+          johndoh/contextmenu \
+    ; \
 ```


### PR DESCRIPTION
I think this var might be needed or plugins won't be functional when installed through the Dockerfile.

Ref: https://getcomposer.org/doc/03-cli.md#composer-allow-superuser