### PR TITLE
Add unzip binary + separate actions to test and publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: 
       - 'master'
+    paths:
+      - '!README.md'
     tags:
       - '*'
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,10 @@
-name: Build Docker image
-on: [push, pull_request]
+name: Build & Publish
+on:
+  push:
+    branches: 
+      - 'master'
+    tags:
+      - '*'
 jobs:
   build-and-testvariants:
     name: Build image variants and run tests
@@ -47,8 +52,6 @@ jobs:
           tags: ${{ matrix.docker-tag }}
           # does not work linux/arm/v5 AND linux/mips64le - composer does not support  mips64le or armv5 nor does the php image support them on the alpine variant
       - name: Run tests
-        env:
-          ROUNDCUBEMAIL_TEST_IMAGE: ${{ matrix.docker-tag }}
         run: |
           set -exu;
           for testFile in ${{ join(matrix.test-files, ' ') }};

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - 'master'
     paths:
       - '!README.md'
+      - '!examples/**'
     tags:
       - '*'
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Build & Test
+on:
+  pull_request: {}
+  push:
+    branches: 
+      - '!master'
+jobs:
+  build-and-testvariants:
+    name: Build image variants and run tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        include:
+          - variant: 'apache'
+            test-files: 'apache-postgres'
+            docker-tag: roundcube/roundcubemail:test-apache
+          - variant: 'fpm'
+            test-files: 'fpm-postgres'
+            docker-tag: roundcube/roundcubemail:test-fpm
+          - variant: 'fpm-alpine'
+            test-files: 'fpm-postgres'
+            docker-tag: roundcube/roundcubemail:test-fpm-alpine
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Get docker hub username
+        id: creds
+        run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
+      - name: Login to Docker Hub
+        if: steps.creds.outputs.username != ''
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_PULL_USERNAME }}
+          password: ${{ secrets.DOCKER_PULL_PASSWORD }}
+
+      - name: Build image for "${{ matrix.variant }}"
+        run: cd ${{ matrix.variant }} && docker buildx build ./ -t ${{ matrix.docker-tag }}
+      - name: Run tests
+        env:
+          ROUNDCUBEMAIL_TEST_IMAGE: ${{ matrix.docker-tag }}
+        run: |
+          set -exu;
+          for testFile in ${{ join(matrix.test-files, ' ') }};
+          do
+            docker-compose -f ./tests/docker-compose.test-${testFile}.yml \
+            up --exit-code-from=sut --abort-on-container-exit
+          done
+          
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Build & Test
 on:
-  pull_request:
-    branches:
-      - '*'
+  pull_request: {}
   push:
     branches: 
       - '!master'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Build & Test
 on:
-  pull_request: {}
+  pull_request:
+    branches:
+      - '*'
   push:
     branches: 
       - '!master'

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -60,6 +60,7 @@ RUN set -ex; \
 			aspell \
 			aspell-en \
 			rsync \
+			unzip \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -10,7 +10,8 @@ RUN set -ex; \
 		rsync \
 		tzdata \
 		aspell \
-		aspell-en
+		aspell-en \
+		unzip
 
 RUN set -ex; \
 	\

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -60,6 +60,7 @@ RUN set -ex; \
 			aspell \
 			aspell-en \
 			rsync \
+			unzip \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/templates/Dockerfile-alpine.templ
+++ b/templates/Dockerfile-alpine.templ
@@ -10,7 +10,8 @@ RUN set -ex; \
 		rsync \
 		tzdata \
 		aspell \
-		aspell-en
+		aspell-en \
+		unzip
 
 RUN set -ex; \
 	\

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -60,6 +60,7 @@ RUN set -ex; \
 			aspell \
 			aspell-en \
 			rsync \
+			unzip \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/tests/docker-compose.test-apache-postgres.yml
+++ b/tests/docker-compose.test-apache-postgres.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   roundcubemail:
-    image: ${ROUNDCUBEMAIL_TEST_IMAGE:roundcube/roundcubemail:latest-apache}
+    image: ${ROUNDCUBEMAIL_TEST_IMAGE:-roundcube/roundcubemail:latest-apache}
     healthcheck:
       # To make it obvious in logs "ping=ping" is added
       test: ["CMD", "curl", "--fail", "http://localhost/?ping=ping"]

--- a/tests/docker-compose.test-apache-postgres.yml
+++ b/tests/docker-compose.test-apache-postgres.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   roundcubemail:
-    image: roundcube/roundcubemail:1.6.0-apache
+    image: ${ROUNDCUBEMAIL_TEST_IMAGE:roundcube/roundcubemail:latest-apache}
     healthcheck:
       # To make it obvious in logs "ping=ping" is added
       test: ["CMD", "curl", "--fail", "http://localhost/?ping=ping"]

--- a/tests/docker-compose.test-fpm-postgres.yml
+++ b/tests/docker-compose.test-fpm-postgres.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   roundcubemail-fpm:
-    image: ${ROUNDCUBEMAIL_TEST_IMAGE:roundcube/roundcubemail:latest-fpm}
+    image: ${ROUNDCUBEMAIL_TEST_IMAGE:-roundcube/roundcubemail:latest-fpm}
     healthcheck:
       # Check until the FPM port is in in the LISTEN list
       # test: ["CMD-SHELL", "netstat -an | grep -q -F \":9000\""]

--- a/tests/docker-compose.test-fpm-postgres.yml
+++ b/tests/docker-compose.test-fpm-postgres.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   roundcubemail-fpm:
-    image: roundcube/roundcubemail:1.6.0-fpm
+    image: ${ROUNDCUBEMAIL_TEST_IMAGE:roundcube/roundcubemail:latest-fpm}
     healthcheck:
       # Check until the FPM port is in in the LISTEN list
       # test: ["CMD-SHELL", "netstat -an | grep -q -F \":9000\""]


### PR DESCRIPTION
Only build and publish multi-arch docker images on pushes to master branch (or tags).
Build single-arch image and run tests on other branches or pull requests.