### PR TITLE
Enable roundcube shell scripts to be directly executed

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 
 # PWD=`pwd`
 
-if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
     echo >&2 "roundcubemail not found in $PWD - copying now..."

--- a/examples/kubernetes.yaml
+++ b/examples/kubernetes.yaml
@@ -145,7 +145,7 @@ spec:
       - name: roundcubemail
         image: roundcube/roundcubemail:latest-fpm-alpine
         imagePullPolicy: ""
-        env:
+        env: &env
         - name: ROUNDCUBEMAIL_DB_TYPE
           value: pgsql
         - name: ROUNDCUBEMAIL_DB_HOST
@@ -278,3 +278,25 @@ spec:
     targetPort: 80
   selector:
     service: roundcubenginx
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleandb
+spec:
+  schedule: "@daily"
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name:  cleandb
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: roundcubemail
+              image: roundcube/roundcubemail:latest-fpm-alpine
+              imagePullPolicy: ""
+              env: *env
+              args:
+                - bin/cleandb.sh

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 
 # PWD=`pwd`
 
-if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
     echo >&2 "roundcubemail not found in $PWD - copying now..."

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 
 # PWD=`pwd`
 
-if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
     echo >&2 "roundcubemail not found in $PWD - copying now..."

--- a/nightly/docker-entrypoint.sh
+++ b/nightly/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 
 # PWD=`pwd`
 
-if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
     echo >&2 "roundcubemail not found in $PWD - copying now..."

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 
 # PWD=`pwd`
 
-if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
     echo >&2 "roundcubemail not found in $PWD - copying now..."


### PR DESCRIPTION
In my Kubernetes cluster I want to define a [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) resource for periodic database cleanup as described [here](https://github.com/roundcube/roundcubemail/blob/372c8bd0cd9c140fbe0d09120c303d6f5d3fb04d/INSTALL#L140).

Ideally, I would like to do this by passing "bin/cleandb.sh" as argument to the entrypoint. See example in the commits.
Currently, this does not work since roundcube is not been copied to the docroot when the first argument passed to the entrypoint does not start with `apache2` or `php-fpm`. 

So I propose to extend the condition in all variants of the entrypoint script.