### PR TITLE
Adding the ROUNDCUBEMAIL_USERNAME_DOMAIN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ The following env variables can be set to configure your Roundcube Docker instan
 
 `ROUNDCUBEMAIL_SMTP_SERVER` - Hostname of the SMTP server to send mails. For encrypted connections, prefix the host with `tls://` (STARTTLS) or `ssl://` (SSL/TLS).
 
-`ROUNDCUBEMAIL_SMTP_PORT`  - SMTP port number; defaults to `587`
+`ROUNDCUBEMAIL_SMTP_PORT` - SMTP port number; defaults to `587`
+
+`ROUNDCUBEMAIL_USERNAME_DOMAIN` - Automatically add this domain to user names for login. See [defaults.inc.php](https://github.com/roundcube/roundcubemail/blob/master/config/defaults.inc.php) for more information.
 
 `ROUNDCUBEMAIL_REQUEST_PATH` - Specify request path with reverse proxy; defaults to `/`. See [defaults.inc.php](https://github.com/roundcube/roundcubemail/blob/master/config/defaults.inc.php) for possible values.
 

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -98,6 +98,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   \$config['db_dsnr'] = '${ROUNDCUBEMAIL_DSNR}';
   \$config['imap_host'] = '${ROUNDCUBEMAIL_DEFAULT_HOST}:${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
+  \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['request_path'] = '${ROUNDCUBEMAIL_REQUEST_PATH}';

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -98,6 +98,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   \$config['db_dsnr'] = '${ROUNDCUBEMAIL_DSNR}';
   \$config['imap_host'] = '${ROUNDCUBEMAIL_DEFAULT_HOST}:${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
+  \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['request_path'] = '${ROUNDCUBEMAIL_REQUEST_PATH}';

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -98,6 +98,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   \$config['db_dsnr'] = '${ROUNDCUBEMAIL_DSNR}';
   \$config['imap_host'] = '${ROUNDCUBEMAIL_DEFAULT_HOST}:${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
+  \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['request_path'] = '${ROUNDCUBEMAIL_REQUEST_PATH}';

--- a/nightly/docker-entrypoint.sh
+++ b/nightly/docker-entrypoint.sh
@@ -99,6 +99,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   \$config['smtp_server'] = '${ROUNDCUBEMAIL_SMTP_SERVER}';
   \$config['smtp_port'] = '${ROUNDCUBEMAIL_SMTP_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
+  \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['plugins'] = array_filter(array_unique(array_merge(\$config['plugins'], ['${ROUNDCUBEMAIL_PLUGINS_PHP}'])));

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -98,6 +98,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   \$config['db_dsnr'] = '${ROUNDCUBEMAIL_DSNR}';
   \$config['imap_host'] = '${ROUNDCUBEMAIL_DEFAULT_HOST}:${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
+  \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['request_path'] = '${ROUNDCUBEMAIL_REQUEST_PATH}';


### PR DESCRIPTION
Added ROUNDCUBEMAIL_USERNAME_DOMAIN which sets the username_domain config option.

I think this could be useful for people whose mail domain isn't the same as the IMAP server hostname (which is really common).

For example, if the IMAP hostname is mail.example.com and someone tries to connect using only the username, roundcube will autocomplete with mail.example.com for the sender address (instead of example.com). In this case, the email address will be user@mail.example.com instead of user@example.com.
If the SMTP server only accepts emails owned by the account, the email will not be sent. It addresses issue #231, which suggests using the mail_domain config option. By the way, I tested the mail_domain option but it only works for new users, that's why I chose to use the username_domain config option.


It could also simplify the login process for people whose mail server only accepts emails as username.