### PR TITLE
Add new ENV ROUNDCUBEMAIL_INSTALL_PLUGINS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ The following env variables can be set to configure your Roundcube Docker instan
 
 `ROUNDCUBEMAIL_PLUGINS` - List of built-in plugins to activate. Defaults to `archive,zipdownload`
 
+`ROUNDCUBEMAIL_INSTALL_PLUGINS` - Set to `1` or `true` to enable installation of plugins on startup
+
 `ROUNDCUBEMAIL_SKIN` - Configures the default theme. Defaults to `larry`
 
 `ROUNDCUBEMAIL_UPLOAD_MAX_FILESIZE` - File upload size limit; defaults to `5M`
@@ -120,16 +122,8 @@ For example, it may be used to increase the PHP memory limit (`memory_limit=128M
 
 ## Installing Roundcube Plugins
 
-With the latest updates, the Roundcube images contain the [Composer](https://getcomposer.org) binary
-which is used to install plugins. You can add and activate plugins by executing `composer require <package-name>` 
-inside a running Roundcube container:
-
-```sh
-docker exec -it roundcubemail composer require johndoh/contextmenu --update-no-dev
-```
-
-If you have mounted the container's volume `/var/www/html` the plugins installed persist on your host system.
-Otherwise they need to be (re-)installed every time you update or restart the Roundcube container.
+With the latest updates, the Roundcube image is now able to install plugins.
+You need to use `ROUNDCUBEMAIL_INSTALL_PLUGINS=1` in the env variables.
 
 ## Examples
 
@@ -148,7 +142,7 @@ docker build -t roundcubemail .
 
 You can also create your own Docker image by extending from this image.
 
-For instance, you could extend this image to add composer and install requirements for builtin plugins or even external plugins:
+For instance, you could extend this image to add composer and install requirements for special plugins:
 
 ```Dockerfile
 FROM roundcube/roundcubemail:latest
@@ -160,16 +154,5 @@ RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         git \
-    ; \
-    \
-    composer \
-      --working-dir=/usr/src/roundcubemail/ \
-      --prefer-dist \
-      --prefer-stable \
-      --update-no-dev \
-      --no-interaction \
-      --optimize-autoloader \
-      require \
-          johndoh/contextmenu \
     ; \
 ```

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -72,6 +72,18 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   : "${ROUNDCUBEMAIL_TEMP_DIR:=/tmp/roundcube-temp}"
   : "${ROUNDCUBEMAIL_REQUEST_PATH:=/}"
 
+  if [ ! -z "${ROUNDCUBEMAIL_INSTALL_PLUGINS}" ]; then
+    echo "Installing plugins from the list"
+    echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
+
+    cd $PWD
+    for plugin in ${ROUNDCUBEMAIL_INSTALL_PLUGINS//,/ }
+    do
+      echo "Installing: $plugin"
+      composer --no-interaction require $plugin
+    done
+  fi
+
   if [ ! -e config/config.inc.php ]; then
     GENERATED_DES_KEY=`head /dev/urandom | base64 | head -c 24`
     touch config/config.inc.php

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -76,12 +76,19 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "Installing plugins from the list"
     echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
 
-    cd $PWD
-    for plugin in ${ROUNDCUBEMAIL_INSTALL_PLUGINS//,/ }
-    do
-      echo "Installing: $plugin"
-      composer --no-interaction require $plugin
-    done
+    # Remove ',' and send the list as is
+    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr -d ','`
+
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+      -- \
+      ${ROUNDCUBEMAIL_PLUGINS_SH};
   fi
 
   if [ ! -e config/config.inc.php ]; then

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -76,8 +76,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "Installing plugins from the list"
     echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
 
-    # Remove ',' and send the list as is
-    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr -d ','`
+    # Change ',' into a space
+    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr ',' ' '`
 
     composer \
       --working-dir=/usr/src/roundcubemail/ \

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
   if [ ! -z "${ROUNDCUBEMAIL_INSTALL_PLUGINS}" ]; then
     echo "Installing plugins from the list"
-    echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
+    echo "Plugins: ${ROUNDCUBEMAIL_PLUGINS}"
 
     # Change ',' into a space
     ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr ',' ' '`

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -72,6 +72,18 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   : "${ROUNDCUBEMAIL_TEMP_DIR:=/tmp/roundcube-temp}"
   : "${ROUNDCUBEMAIL_REQUEST_PATH:=/}"
 
+  if [ ! -z "${ROUNDCUBEMAIL_INSTALL_PLUGINS}" ]; then
+    echo "Installing plugins from the list"
+    echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
+
+    cd $PWD
+    for plugin in ${ROUNDCUBEMAIL_INSTALL_PLUGINS//,/ }
+    do
+      echo "Installing: $plugin"
+      composer --no-interaction require $plugin
+    done
+  fi
+
   if [ ! -e config/config.inc.php ]; then
     GENERATED_DES_KEY=`head /dev/urandom | base64 | head -c 24`
     touch config/config.inc.php

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -76,12 +76,19 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "Installing plugins from the list"
     echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
 
-    cd $PWD
-    for plugin in ${ROUNDCUBEMAIL_INSTALL_PLUGINS//,/ }
-    do
-      echo "Installing: $plugin"
-      composer --no-interaction require $plugin
-    done
+    # Remove ',' and send the list as is
+    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr -d ','`
+
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+      -- \
+      ${ROUNDCUBEMAIL_PLUGINS_SH};
   fi
 
   if [ ! -e config/config.inc.php ]; then

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -76,8 +76,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "Installing plugins from the list"
     echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
 
-    # Remove ',' and send the list as is
-    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr -d ','`
+    # Change ',' into a space
+    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr ',' ' '`
 
     composer \
       --working-dir=/usr/src/roundcubemail/ \

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
   if [ ! -z "${ROUNDCUBEMAIL_INSTALL_PLUGINS}" ]; then
     echo "Installing plugins from the list"
-    echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
+    echo "Plugins: ${ROUNDCUBEMAIL_PLUGINS}"
 
     # Change ',' into a space
     ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr ',' ' '`

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -72,6 +72,18 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   : "${ROUNDCUBEMAIL_TEMP_DIR:=/tmp/roundcube-temp}"
   : "${ROUNDCUBEMAIL_REQUEST_PATH:=/}"
 
+  if [ ! -z "${ROUNDCUBEMAIL_INSTALL_PLUGINS}" ]; then
+    echo "Installing plugins from the list"
+    echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
+
+    cd $PWD
+    for plugin in ${ROUNDCUBEMAIL_INSTALL_PLUGINS//,/ }
+    do
+      echo "Installing: $plugin"
+      composer --no-interaction require $plugin
+    done
+  fi
+
   if [ ! -e config/config.inc.php ]; then
     GENERATED_DES_KEY=`head /dev/urandom | base64 | head -c 24`
     touch config/config.inc.php

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -76,12 +76,19 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "Installing plugins from the list"
     echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
 
-    cd $PWD
-    for plugin in ${ROUNDCUBEMAIL_INSTALL_PLUGINS//,/ }
-    do
-      echo "Installing: $plugin"
-      composer --no-interaction require $plugin
-    done
+    # Remove ',' and send the list as is
+    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr -d ','`
+
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+      -- \
+      ${ROUNDCUBEMAIL_PLUGINS_SH};
   fi
 
   if [ ! -e config/config.inc.php ]; then

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -76,8 +76,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "Installing plugins from the list"
     echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
 
-    # Remove ',' and send the list as is
-    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr -d ','`
+    # Change ',' into a space
+    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr ',' ' '`
 
     composer \
       --working-dir=/usr/src/roundcubemail/ \

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
   if [ ! -z "${ROUNDCUBEMAIL_INSTALL_PLUGINS}" ]; then
     echo "Installing plugins from the list"
-    echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
+    echo "Plugins: ${ROUNDCUBEMAIL_PLUGINS}"
 
     # Change ',' into a space
     ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr ',' ' '`

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -72,6 +72,25 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   : "${ROUNDCUBEMAIL_TEMP_DIR:=/tmp/roundcube-temp}"
   : "${ROUNDCUBEMAIL_REQUEST_PATH:=/}"
 
+  if [ ! -z "${ROUNDCUBEMAIL_INSTALL_PLUGINS}" ]; then
+    echo "Installing plugins from the list"
+    echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
+
+    # Remove ',' and send the list as is
+    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr -d ','`
+
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+      -- \
+      ${ROUNDCUBEMAIL_PLUGINS_SH};
+  fi
+
   if [ ! -e config/config.inc.php ]; then
     GENERATED_DES_KEY=`head /dev/urandom | base64 | head -c 24`
     touch config/config.inc.php

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -76,8 +76,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "Installing plugins from the list"
     echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
 
-    # Remove ',' and send the list as is
-    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr -d ','`
+    # Change ',' into a space
+    ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr ',' ' '`
 
     composer \
       --working-dir=/usr/src/roundcubemail/ \

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
 
   if [ ! -z "${ROUNDCUBEMAIL_INSTALL_PLUGINS}" ]; then
     echo "Installing plugins from the list"
-    echo "Plugins: ${ROUNDCUBEMAIL_INSTALL_PLUGINS}"
+    echo "Plugins: ${ROUNDCUBEMAIL_PLUGINS}"
 
     # Change ',' into a space
     ROUNDCUBEMAIL_PLUGINS_SH=`echo "${ROUNDCUBEMAIL_PLUGINS}" | tr ',' ' '`


### PR DESCRIPTION
Closes: https://github.com/roundcube/roundcubemail-docker/pull/104

This PR replaces #104 and uses another way of doing the changes that was documented on the README for years.