### PR TITLE
Oauth client secret as docker secret for roundcube docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ to share credentials across all instances. The following secrets are currently s
 * `roundcube_des_key`: Unique and random key for encryption purposes
 * `roundcube_db_user`: Database connection username (mappend to `ROUNDCUBEMAIL_DB_USER`)
 * `roundcube_db_password`: Database connection password (mappend to `ROUNDCUBEMAIL_DB_PASSWORD`)
+* `roundcube_oauth_client_secret`: OAuth client secret (mappend to `ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET`)
 
 ## Advanced configuration
 

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -27,6 +27,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   if [ -f /run/secrets/roundcube_db_password ]; then
     ROUNDCUBEMAIL_DB_PASSWORD=`cat /run/secrets/roundcube_db_password`
   fi
+  if [ -f /run/secrets/roundcube_oauth_client_secret ]; then
+    ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET=`cat /run/secrets/roundcube_oauth_client_secret`
+  fi
 
   if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
@@ -108,6 +111,10 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "\$config['des_key'] = file_get_contents('/run/secrets/roundcube_des_key');" >> config/config.docker.inc.php
   elif [ ! -z "${ROUNDCUBEMAIL_DES_KEY}" ]; then
     echo "\$config['des_key'] = getenv('ROUNDCUBEMAIL_DES_KEY');" >> config/config.docker.inc.php
+  fi
+
+  if [ ! -z "${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}" ]; then
+    echo "\$config['oauth_client_secret'] = '${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}';" >> config/config.docker.inc.php
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}"]; then

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -27,6 +27,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   if [ -f /run/secrets/roundcube_db_password ]; then
     ROUNDCUBEMAIL_DB_PASSWORD=`cat /run/secrets/roundcube_db_password`
   fi
+  if [ -f /run/secrets/roundcube_oauth_client_secret ]; then
+    ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET=`cat /run/secrets/roundcube_oauth_client_secret`
+  fi
 
   if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
@@ -108,6 +111,10 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "\$config['des_key'] = file_get_contents('/run/secrets/roundcube_des_key');" >> config/config.docker.inc.php
   elif [ ! -z "${ROUNDCUBEMAIL_DES_KEY}" ]; then
     echo "\$config['des_key'] = getenv('ROUNDCUBEMAIL_DES_KEY');" >> config/config.docker.inc.php
+  fi
+
+  if [ ! -z "${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}" ]; then
+    echo "\$config['oauth_client_secret'] = '${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}';" >> config/config.docker.inc.php
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}"]; then

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -27,6 +27,9 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   if [ -f /run/secrets/roundcube_db_password ]; then
     ROUNDCUBEMAIL_DB_PASSWORD=`cat /run/secrets/roundcube_db_password`
   fi
+  if [ -f /run/secrets/roundcube_oauth_client_secret ]; then
+    ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET=`cat /run/secrets/roundcube_oauth_client_secret`
+  fi
 
   if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
@@ -108,6 +111,10 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "\$config['des_key'] = file_get_contents('/run/secrets/roundcube_des_key');" >> config/config.docker.inc.php
   elif [ ! -z "${ROUNDCUBEMAIL_DES_KEY}" ]; then
     echo "\$config['des_key'] = getenv('ROUNDCUBEMAIL_DES_KEY');" >> config/config.docker.inc.php
+  fi
+
+  if [ ! -z "${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}" ]; then
+    echo "\$config['oauth_client_secret'] = '${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}';" >> config/config.docker.inc.php
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}"]; then

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -27,6 +27,10 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   if [ -f /run/secrets/roundcube_db_password ]; then
     ROUNDCUBEMAIL_DB_PASSWORD=`cat /run/secrets/roundcube_db_password`
   fi
+  if [ -f /run/secrets/roundcube_oauth_client_secret ]; then
+    ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET=`cat /run/secrets/roundcube_oauth_client_secret`
+  fi
+
 
   if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
@@ -108,6 +112,10 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     echo "\$config['des_key'] = file_get_contents('/run/secrets/roundcube_des_key');" >> config/config.docker.inc.php
   elif [ ! -z "${ROUNDCUBEMAIL_DES_KEY}" ]; then
     echo "\$config['des_key'] = getenv('ROUNDCUBEMAIL_DES_KEY');" >> config/config.docker.inc.php
+  fi
+
+  if [ ! -z "${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}" ]; then
+    echo "\$config['oauth_client_secret'] = '${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}';" >> config/config.docker.inc.php
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}"]; then

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -31,7 +31,6 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
     ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET=`cat /run/secrets/roundcube_oauth_client_secret`
   fi
 
-
   if [ ! -z "${!POSTGRES_ENV_POSTGRES_*}" ] || [ "$ROUNDCUBEMAIL_DB_TYPE" == "pgsql" ]; then
     : "${ROUNDCUBEMAIL_DB_TYPE:=pgsql}"
     : "${ROUNDCUBEMAIL_DB_HOST:=postgres}"


### PR DESCRIPTION
This pull request adds support for roundcube_oauth_client_secret as docker secret, which is then injected into the appropriate roundcube configuration variable. This way, the user  can keep all secrets out of compose.yml files.