### PR TITLE
Install missing skin via composer on system initialization

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -104,6 +104,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
     # Installing missing skin
+    echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
     composer \
       --working-dir=/usr/src/roundcubemail/ \
       --prefer-dist \

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -102,6 +102,20 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
       ${ROUNDCUBEMAIL_COMPOSER_PLUGINS_SH};
   fi
 
+  if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
+    # Installing missing skin
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+      -- \
+      roundcube/${ROUNDCUBEMAIL_SKIN};
+  fi
+
   if [ ! -e config/config.inc.php ]; then
     GENERATED_DES_KEY=`head /dev/urandom | base64 | head -c 24`
     touch config/config.inc.php

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -106,22 +106,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
     # Installing missing skin
     echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
     composer \
-      --working-dir=/usr/src/roundcubemail/ \
-      --prefer-dist \
-      --prefer-stable \
-      --update-no-dev \
-      --no-interaction \
-      --optimize-autoloader \
-      require \
-      -- \
-      roundcube/${ROUNDCUBEMAIL_SKIN};
-  fi
-
-  if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
-    # Installing missing skin
-    echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
-    composer \
-      --working-dir=/usr/src/roundcubemail/ \
+      --working-dir=${INSTALLDIR} \
       --prefer-dist \
       --prefer-stable \
       --update-no-dev \

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -104,6 +104,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
     # Installing missing skin
+    echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
     composer \
       --working-dir=/usr/src/roundcubemail/ \
       --prefer-dist \

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -102,6 +102,20 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
       ${ROUNDCUBEMAIL_COMPOSER_PLUGINS_SH};
   fi
 
+  if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
+    # Installing missing skin
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+      -- \
+      roundcube/${ROUNDCUBEMAIL_SKIN};
+  fi
+
   if [ ! -e config/config.inc.php ]; then
     GENERATED_DES_KEY=`head /dev/urandom | base64 | head -c 24`
     touch config/config.inc.php

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -106,22 +106,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
     # Installing missing skin
     echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
     composer \
-      --working-dir=/usr/src/roundcubemail/ \
-      --prefer-dist \
-      --prefer-stable \
-      --update-no-dev \
-      --no-interaction \
-      --optimize-autoloader \
-      require \
-      -- \
-      roundcube/${ROUNDCUBEMAIL_SKIN};
-  fi
-
-  if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
-    # Installing missing skin
-    echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
-    composer \
-      --working-dir=/usr/src/roundcubemail/ \
+      --working-dir=${INSTALLDIR} \
       --prefer-dist \
       --prefer-stable \
       --update-no-dev \

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -104,6 +104,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
     # Installing missing skin
+    echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
     composer \
       --working-dir=/usr/src/roundcubemail/ \
       --prefer-dist \

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -102,6 +102,20 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
       ${ROUNDCUBEMAIL_COMPOSER_PLUGINS_SH};
   fi
 
+  if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
+    # Installing missing skin
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+      -- \
+      roundcube/${ROUNDCUBEMAIL_SKIN};
+  fi
+
   if [ ! -e config/config.inc.php ]; then
     GENERATED_DES_KEY=`head /dev/urandom | base64 | head -c 24`
     touch config/config.inc.php

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -106,22 +106,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
     # Installing missing skin
     echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
     composer \
-      --working-dir=/usr/src/roundcubemail/ \
-      --prefer-dist \
-      --prefer-stable \
-      --update-no-dev \
-      --no-interaction \
-      --optimize-autoloader \
-      require \
-      -- \
-      roundcube/${ROUNDCUBEMAIL_SKIN};
-  fi
-
-  if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
-    # Installing missing skin
-    echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
-    composer \
-      --working-dir=/usr/src/roundcubemail/ \
+      --working-dir=${INSTALLDIR} \
       --prefer-dist \
       --prefer-stable \
       --update-no-dev \

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -104,6 +104,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
     # Installing missing skin
+    echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
     composer \
       --working-dir=/usr/src/roundcubemail/ \
       --prefer-dist \

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -102,6 +102,20 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
       ${ROUNDCUBEMAIL_COMPOSER_PLUGINS_SH};
   fi
 
+  if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
+    # Installing missing skin
+    composer \
+      --working-dir=/usr/src/roundcubemail/ \
+      --prefer-dist \
+      --prefer-stable \
+      --update-no-dev \
+      --no-interaction \
+      --optimize-autoloader \
+      require \
+      -- \
+      roundcube/${ROUNDCUBEMAIL_SKIN};
+  fi
+
   if [ ! -e config/config.inc.php ]; then
     GENERATED_DES_KEY=`head /dev/urandom | base64 | head -c 24`
     touch config/config.inc.php

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -106,22 +106,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
     # Installing missing skin
     echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
     composer \
-      --working-dir=/usr/src/roundcubemail/ \
-      --prefer-dist \
-      --prefer-stable \
-      --update-no-dev \
-      --no-interaction \
-      --optimize-autoloader \
-      require \
-      -- \
-      roundcube/${ROUNDCUBEMAIL_SKIN};
-  fi
-
-  if [ ! -d skins/${ROUNDCUBEMAIL_SKIN} ]; then
-    # Installing missing skin
-    echo "Installing missing skin: ${ROUNDCUBEMAIL_SKIN}"
-    composer \
-      --working-dir=/usr/src/roundcubemail/ \
+      --working-dir=${INSTALLDIR} \
       --prefer-dist \
       --prefer-stable \
       --update-no-dev \

--- a/tests/docker-compose.test-apache-postgres.yml
+++ b/tests/docker-compose.test-apache-postgres.yml
@@ -23,6 +23,7 @@ services:
       - ROUNDCUBEMAIL_DB_NAME=roundcube # same as pgsql POSTGRES_DB env name
       - ROUNDCUBEMAIL_DB_USER=roundcube # same as pgsql POSTGRES_USER env name
       - ROUNDCUBEMAIL_DB_PASSWORD=roundcube # same as pgsql POSTGRES_PASSWORD env name
+      - ROUNDCUBEMAIL_SKIN=larry # Install non-default skin
 
   roundcubedb:
     image: postgres:alpine

--- a/tests/docker-compose.test-fpm-postgres.yml
+++ b/tests/docker-compose.test-fpm-postgres.yml
@@ -27,6 +27,7 @@ services:
       - ROUNDCUBEMAIL_DB_NAME=roundcube # same as pgsql POSTGRES_DB env name
       - ROUNDCUBEMAIL_DB_USER=roundcube # same as pgsql POSTGRES_USER env name
       - ROUNDCUBEMAIL_DB_PASSWORD=roundcube # same as pgsql POSTGRES_PASSWORD env name
+      - ROUNDCUBEMAIL_SKIN=larry # Install non-default skin
 
   roundcubedb:
     image: postgres:alpine


### PR DESCRIPTION
Only classic skin ist included in core. So if you define ROUNDCUBEMAIL_SKIN to anything other, you will get an 404 (also see #243) unless you install missing skin. This contribution will install the missing skin on system startup.