### PR TITLE
Fix syntax error in docker-entrypoint.sh

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -145,7 +145,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
     echo "\$config['oauth_client_secret'] = '${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}';" >> config/config.docker.inc.php
   fi
 
-  if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}"]; then
+  if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}" ]; then
     echo "\$config['spellcheck_engine'] = 'googie';" >> config/config.docker.inc.php
     echo "\$config['spellcheck_uri'] = '${ROUNDCUBEMAIL_SPELLCHECK_URI}';" >> config/config.docker.inc.php
   fi

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -145,7 +145,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
     echo "\$config['oauth_client_secret'] = '${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}';" >> config/config.docker.inc.php
   fi
 
-  if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}"]; then
+  if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}" ]; then
     echo "\$config['spellcheck_engine'] = 'googie';" >> config/config.docker.inc.php
     echo "\$config['spellcheck_uri'] = '${ROUNDCUBEMAIL_SPELLCHECK_URI}';" >> config/config.docker.inc.php
   fi

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -145,7 +145,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
     echo "\$config['oauth_client_secret'] = '${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}';" >> config/config.docker.inc.php
   fi
 
-  if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}"]; then
+  if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}" ]; then
     echo "\$config['spellcheck_engine'] = 'googie';" >> config/config.docker.inc.php
     echo "\$config['spellcheck_uri'] = '${ROUNDCUBEMAIL_SPELLCHECK_URI}';" >> config/config.docker.inc.php
   fi

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -145,7 +145,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
     echo "\$config['oauth_client_secret'] = '${ROUNDCUBEMAIL_OAUTH_CLIENT_SECRET}';" >> config/config.docker.inc.php
   fi
 
-  if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}"]; then
+  if [ ! -z "${ROUNDCUBEMAIL_SPELLCHECK_URI}" ]; then
     echo "\$config['spellcheck_engine'] = 'googie';" >> config/config.docker.inc.php
     echo "\$config['spellcheck_uri'] = '${ROUNDCUBEMAIL_SPELLCHECK_URI}';" >> config/config.docker.inc.php
   fi


### PR DESCRIPTION
It would seem that a very minor typo has been floating around

`/docker-entrypoint.sh: line 148: [: missing ']'`

Super simple fix, add a space.