### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:8.1-apache
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
+LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
 RUN set -ex; \
 	apt-get update; \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:8.1-fpm-alpine
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
+LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
 # entrypoint.sh and installto.sh dependencies
 RUN set -ex; \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:8.1-fpm
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
+LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
 RUN set -ex; \
 	apt-get update; \

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:8.0-apache AS base
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
+LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
 RUN set -ex; \
 	apt-get update; \

--- a/templates/Dockerfile-alpine.templ
+++ b/templates/Dockerfile-alpine.templ
@@ -1,5 +1,6 @@
 FROM php:8.1-%%VARIANT%%
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
+LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
 # entrypoint.sh and installto.sh dependencies
 RUN set -ex; \

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -1,5 +1,6 @@
 FROM php:8.1-%%VARIANT%%
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
+LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
 RUN set -ex; \
 	apt-get update; \


### PR DESCRIPTION
same as https://github.com/roundcube/roundcubemail/pull/9667

> To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.
> 
> For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md