### PR TITLE
Rebuild weekly to ensure fresh base images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
       - 'examples/**'
     tags:
       - '1.6.*'
+  schedule:
+    # Rebuild images each monday early morning to ensure a fresh base OS.
+    - cron: "23 2 * * 1"
+
 jobs:
   build-and-testvariants:
     name: Build image variants and run tests


### PR DESCRIPTION
Rebuilding regularly is good practice to ensure that the used base images are fresh.

Currently our images get quite old if no releases happen.