### PR TITLE
Remove needlessly published ports from examples

### DIFF
--- a/examples/docker-compose-fpm-alpine.yaml
+++ b/examples/docker-compose-fpm-alpine.yaml
@@ -9,8 +9,6 @@ services:
       - roundcubedb
     links:
       - roundcubedb
-    ports:
-      - 9000:9000
     volumes:
       - ./www:/var/www/html
     environment:
@@ -27,8 +25,6 @@ services:
     image: postgres:alpine
     container_name: roundcubedb
     # restart: unless-stopped
-    ports:
-      - 5432:5432
     volumes:
       - ./db/postgres:/var/lib/postgresql/data
     environment:

--- a/examples/docker-compose-fpm.yaml
+++ b/examples/docker-compose-fpm.yaml
@@ -9,8 +9,6 @@ services:
       - roundcubedb
     links:
       - roundcubedb
-    ports:
-      - 9000:9000
     volumes:
       - ./www:/var/www/html
     environment:
@@ -27,8 +25,6 @@ services:
     image: postgres:latest
     container_name: roundcubedb
     # restart: unless-stopped
-    ports:
-      - 5432:5432
     volumes:
       - ./db/postgres:/var/lib/postgresql/data
     environment:

--- a/examples/docker-compose-mysql.yaml
+++ b/examples/docker-compose-mysql.yaml
@@ -7,9 +7,6 @@ services:
 #    restart: unless-stopped
     volumes:
       - ./db/mysql:/var/lib/mysql
-    ports:
-      - 34010:5432
-      - 33006:3306
     environment:
       - MYSQL_ROOT_PASSWORD=roundcube-mysql-pw
       - MYSQL_DATABASE=roundcubemail


### PR DESCRIPTION
Publishing the FPM port can even be dangerous if the image is run using docker, which manipulates firewalls to provide access from the public to all published ports.

Fixes #129 