### PR TITLE
Fix update.sh for use on BSD/Darwin

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -34,7 +34,9 @@ for variant in apache fpm fpm-alpine; do
 	echo "✓ Wrote $dir/Dockerfile"
 done
 
-sed -i -E "s/1\.[0-9]\.[0-9]+-/${VERSION}-/" .github/workflows/build.yml
+# Use perl to avoid problems with BSD vs. GNU sed, which have incompatible
+# argument syntax for editing files in-place.
+perl -pi -e "s/1\.[0-9]\.[0-9]+-/${VERSION}-/" .github/workflows/build.yml
 echo "Updating version in build.yml workflow"
 
 echo "Done."


### PR DESCRIPTION
BSD vs. GNU sed have incompatible argument syntax for editing files in-place.
We now simply use good old perl, instead of ugly workarounds.