### PR TITLE
Limit reminder-bots to our repo

### DIFF
--- a/.github/workflows/bot-create-manual-reminder.yml
+++ b/.github/workflows/bot-create-manual-reminder.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   reminder:
+    if: github.repository == 'roundcube/roundcubemail-docker'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/bot-manual-reminder.yml
+++ b/.github/workflows/bot-manual-reminder.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   reminder:
+    if: github.repository == 'roundcube/roundcubemail-docker'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/bot-remind-stale-pull-requests.yml
+++ b/.github/workflows/bot-remind-stale-pull-requests.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   review-reminder:
+    if: github.repository == 'roundcube/roundcubemail-docker'
     runs-on: ubuntu-latest
     steps:
       - uses: sojusan/github-action-reminder@v1


### PR DESCRIPTION
Previously these bots would work on all forks, too. Which is not a good default, in my eyes, but anyway here's a change that stops that.