### PR TITLE
Protect default `temp_dir` and `log_dir` from remote access

### DIFF
--- a/examples/nginx/templates/default.conf.template
+++ b/examples/nginx/templates/default.conf.template
@@ -5,6 +5,11 @@ server {
     access_log /var/log/nginx/access.log;
     root /var/www/html;
 
+    location ~ /(temp|logs)/ {
+        deny all;
+        return 403;
+    }
+
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;


### PR DESCRIPTION
The .htaccess doesn't work in nginx

Remote access to those directories might lead to severe information leaks: roundcube/roundcubemail#8851