### PR TITLE
Use a branch a pull requests to propose changes from update.sh

### DIFF
--- a/.github/workflows/update-sh.yml
+++ b/.github/workflows/update-sh.yml
@@ -26,9 +26,11 @@ jobs:
       run: |
         git config --local user.email "workflow@github.com"
         git config --local user.name "GitHub Workflow"
+        git switch -C changes-from-update.sh
         git add -A
         git commit -m "Update roundcube version (via update.sh)" || echo "Nothing to update"
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.WOKFLOW_TOKEN }}
+        git push --force-with-lease origin
+    - name: Create Pull Request
+      run: gh pr create -B master -H changes-from-update.sh --title 'Changes from update.sh' --assignee pabzm
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pushing into the "master" branch is not allowed anymore. Instead of allow-listing the workflow action this changes the workflow action code to open a pull request with the committed changes.
This way we also avoid unexpected changes to the repo in case update.sh changes more than the version number.