### PR TITLE
Keep PHP header files

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -56,8 +56,6 @@ RUN set -ex; \
 	; \
 	docker-php-ext-enable imagick opcache redis; \
 	docker-php-source delete; \
-# Header files ".h"
-	rm -r /usr/local/include/php/ext; \
 	rm -r /tmp/pear; \
 # Display installed modules
 	php -m; \


### PR DESCRIPTION
They might be required by other packages that people building derived container images might want to install.

Fixes #286