### PR TITLE
Test and fix using "enigma" plugin

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   # If the "enigma" plugin is enabled but has no storage configured, inject a default value for the mandatory setting.
   if $(echo $ROUNDCUBEMAIL_PLUGINS | grep -Eq '\benigma\b') && ! grep -qr enigma_pgp_homedir /var/roundcube/config/; then
-    echo "$config['enigma_pgp_homedir'] = '/var/roundcube/enigma';" >> config/config.docker.inc.php
+    echo "\$config['enigma_pgp_homedir'] = '/var/roundcube/enigma';" >> config/config.docker.inc.php
   fi
 
   # include custom config files

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   # If the "enigma" plugin is enabled but has no storage configured, inject a default value for the mandatory setting.
   if $(echo $ROUNDCUBEMAIL_PLUGINS | grep -Eq '\benigma\b') && ! grep -qr enigma_pgp_homedir /var/roundcube/config/; then
-    echo "$config['enigma_pgp_homedir'] = '/var/roundcube/enigma';" >> config/config.docker.inc.php
+    echo "\$config['enigma_pgp_homedir'] = '/var/roundcube/enigma';" >> config/config.docker.inc.php
   fi
 
   # include custom config files

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   # If the "enigma" plugin is enabled but has no storage configured, inject a default value for the mandatory setting.
   if $(echo $ROUNDCUBEMAIL_PLUGINS | grep -Eq '\benigma\b') && ! grep -qr enigma_pgp_homedir /var/roundcube/config/; then
-    echo "$config['enigma_pgp_homedir'] = '/var/roundcube/enigma';" >> config/config.docker.inc.php
+    echo "\$config['enigma_pgp_homedir'] = '/var/roundcube/enigma';" >> config/config.docker.inc.php
   fi
 
   # include custom config files

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -152,7 +152,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   # If the "enigma" plugin is enabled but has no storage configured, inject a default value for the mandatory setting.
   if $(echo $ROUNDCUBEMAIL_PLUGINS | grep -Eq '\benigma\b') && ! grep -qr enigma_pgp_homedir /var/roundcube/config/; then
-    echo "$config['enigma_pgp_homedir'] = '/var/roundcube/enigma';" >> config/config.docker.inc.php
+    echo "\$config['enigma_pgp_homedir'] = '/var/roundcube/enigma';" >> config/config.docker.inc.php
   fi
 
   # include custom config files

--- a/tests/docker-compose.test-fpm-postgres.yml
+++ b/tests/docker-compose.test-fpm-postgres.yml
@@ -27,6 +27,7 @@ services:
       - ROUNDCUBEMAIL_DB_NAME=roundcube # same as pgsql POSTGRES_DB env name
       - ROUNDCUBEMAIL_DB_USER=roundcube # same as pgsql POSTGRES_USER env name
       - ROUNDCUBEMAIL_DB_PASSWORD=roundcube # same as pgsql POSTGRES_PASSWORD env name
+      - ROUNDCUBEMAIL_PLUGINS=enigma
 
   roundcubedb:
     image: postgres:alpine


### PR DESCRIPTION
This fixes specifying "enigma" in `ROUNCUBEMAIL_PLUGINS`. Previously the config was broken in that case.

Additionally one of the test-setups now uses that way to enable the "enigma" plugin to test the config variable injection.


Closes #295