### PR TITLE
Fix the update.sh workflow action to handle no changes

### DIFF
--- a/.github/workflows/update-sh.yml
+++ b/.github/workflows/update-sh.yml
@@ -24,16 +24,17 @@ jobs:
     - name: Run update.sh script
       run: ./update.sh
     - name: Commit files
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        BRANCH="changes-from-update.sh-$(date +'%Y-%m-%d')"
-        git show-ref --quiet "$BRANCH" && { "ERROR: Branch $BRANCH already exists";  exit 1; }
+        # Exit early if no changes are present.
+        test $(git status --porcelain | wc -l) -gt 0 || { echo "No changes to commit, happily cancelling this script."; exit 0; }
+        # Use a distinct branch-name (nano-seconds should be good enough).
+        BRANCH="changes-from-update.sh-$(date -I ns)"
         git switch -C "$BRANCH"
         git config --local user.email "workflow@github.com"
         git config --local user.name "GitHub Workflow"
         git add -A
-        git commit -m "Update roundcube version (via update.sh)" || echo "Nothing to update"
+        git commit -m "Update roundcube version (via update.sh)"
         git push --set-upstream origin "$BRANCH"
-    - name: Create Pull Request
-      run: gh pr create -B master -H changes-from-update.sh --title 'Changes from update.sh' --body "These are the changes of the automated run of ./update.sh" --assignee pabzm
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        gh pr create -B master -H changes-from-update.sh --title 'Changes from update.sh' --body "These are the changes of the automated run of ./update.sh" --assignee pabzm


### PR DESCRIPTION
Previously the branch was created and pushed no matter if changes were
committed, which made subsequent runs fail. This is fixed by using
distinctly named branches, and by exiting early if no changes are to be
committed.