### PR TITLE
Remove TLS-related details from examples

### DIFF
--- a/examples/docker-compose-fpm-alpine.yaml
+++ b/examples/docker-compose-fpm-alpine.yaml
@@ -38,8 +38,6 @@ services:
     # restart: unless-stopped
     ports:
       - 9008:80
-      # If you need SSL connection
-      # - '443:443'
     depends_on:
       - roundcubemail
     links:
@@ -49,9 +47,6 @@ services:
       - ./nginx/templates:/etc/nginx/templates
       # Provide a custom nginx conf
       # - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      # If you need SSL connection, you can provide your own certificates
-      # - ./certs:/etc/letsencrypt
-      # - ./certs-data:/data/letsencrypt
     environment:
       - NGINX_HOST=localhost # set your local domain or your live domain
       - NGINX_PHP_CGI=roundcubemail:9000 # same as roundcubemail container name

--- a/examples/docker-compose-fpm.yaml
+++ b/examples/docker-compose-fpm.yaml
@@ -38,8 +38,6 @@ services:
     # restart: unless-stopped
     ports:
       - 9009:80
-      # If you need SSL connection
-      # - '443:443'
     depends_on:
       - roundcubemail
     links:
@@ -49,9 +47,6 @@ services:
       - ./nginx/templates:/etc/nginx/templates
       # Provide a custom nginx conf
       # - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      # If you need SSL connection, you can provide your own certificates
-      # - ./certs:/etc/letsencrypt
-      # - ./certs-data:/data/letsencrypt
     environment:
       - NGINX_HOST=localhost  # set your local domain or your live domain
       - NGINX_PHP_CGI=roundcubemail:9000  # same as roundcubemail container name


### PR DESCRIPTION
They hint on a possibility that isn't fleshed out, and mislead people to think something is broken because HTTPS doesn't work out of the box.