### PR TITLE
WIP: Add custom ca-certificate import into docker-entrypoint

### DIFF
--- a/templates/Dockerfile-alpine.templ
+++ b/templates/Dockerfile-alpine.templ
@@ -109,5 +109,7 @@ RUN set -ex; \
 # Create the config dir
 	mkdir -p /var/roundcube/config /var/roundcube/enigma
 
+VOLUME /certs
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -115,5 +115,7 @@ RUN set -ex; \
 # Create the config dir
 	mkdir -p /var/roundcube/config /var/roundcube/enigma
 
+VOLUME /certs
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -3,6 +3,16 @@
 
 # PWD=`pwd`
 
+# prepare TLS truststore with custom certificates
+if [ -d /certs ]
+then
+    if compgen -G "/certs/*.crt" >/dev/null
+    then
+        cp -v /certs/*.crt /usr/local/share/ca-certificates/
+        update-ca-certificates
+    fi
+fi
+
 if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   INSTALLDIR=`pwd`
   # docroot is empty


### PR DESCRIPTION
Pull-Request for Issue #237.

This pull request extends the container images to include the ability to insert custom CA certificates by mounting a volume when starting the container.

The implementation is not yet complete:

- [ ] Roundcube-Konfiguration
- [ ] Documentation
- [ ] Tests