### PR TITLE
feat: build non-root image variants

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,32 @@ jobs:
             test-files: 'apache-postgres'
             docker-tag: roundcube/roundcubemail:1.6.x-apache,roundcube/roundcubemail:1.6.9-apache,roundcube/roundcubemail:latest-apache,roundcube/roundcubemail:latest
             test-tag: roundcube/roundcubemail:latest-apache
+            target: 'root'
           - variant: 'fpm'
             test-files: 'fpm-postgres'
             docker-tag: roundcube/roundcubemail:1.6.x-fpm,roundcube/roundcubemail:1.6.9-fpm,roundcube/roundcubemail:latest-fpm
             test-tag: roundcube/roundcubemail:latest-fpm
+            target: 'root'
           - variant: 'fpm-alpine'
             test-files: 'fpm-postgres'
             docker-tag: roundcube/roundcubemail:1.6.x-fpm-alpine,roundcube/roundcubemail:1.6.9-fpm-alpine,roundcube/roundcubemail:latest-fpm-alpine
             test-tag: roundcube/roundcubemail:latest-fpm-alpine
+            target: 'root'
+          - variant: 'apache'
+            test-files: 'apache-postgres'
+            docker-tag: roundcube/roundcubemail-nonroot:1.6.x-apache,roundcube/roundcubemail-nonroot:1.6.9-apache,roundcube/roundcubemail-nonroot:latest-apache,roundcube/roundcubemail-nonroot:latest
+            test-tag: roundcube/roundcubemail-nonroot:latest-apache
+            target: 'nonroot'
+          - variant: 'fpm'
+            test-files: 'apache-postgres'
+            docker-tag: roundcube/roundcubemail-nonroot:1.6.x-fpm,roundcube/roundcubemail-nonroot:1.6.9-fpm,roundcube/roundcubemail-nonroot:latest-fpm
+            test-tag: roundcube/roundcubemail-nonroot:latest-fpm
+            target: 'nonroot'
+          - variant: 'fpm-alpine'
+            test-files: 'apache-postgres'
+            docker-tag: roundcube/roundcubemail-nonroot:1.6.x-fpm-alpine,roundcube/roundcubemail-nonroot:1.6.9-fpm-alpine,roundcube/roundcubemail-nonroot:latest-fpm-alpine
+            test-tag: roundcube/roundcubemail-nonroot:latest-fpm-alpine
+            target: 'nonroot'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -64,6 +82,7 @@ jobs:
           platforms: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/s390x,linux/ppc64le,linux/386,linux/amd64,"
           push: true
           tags: ${{ matrix.docker-tag }}
+          target: ${{ matrix.target }}
           # does not work linux/arm/v5 AND linux/mips64le - composer does not support  mips64le or armv5 nor does the php image support them on the alpine variant
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,27 @@ jobs:
           - variant: 'apache'
             test-files: 'apache-postgres'
             docker-tag: roundcube/roundcubemail:test-apache
+            target: 'root'
           - variant: 'fpm'
             test-files: 'fpm-postgres'
             docker-tag: roundcube/roundcubemail:test-fpm
+            target: 'root'
           - variant: 'fpm-alpine'
             test-files: 'fpm-postgres'
             docker-tag: roundcube/roundcubemail:test-fpm-alpine
+            target: 'root'
+          - variant: 'apache'
+            test-files: 'apache-postgres'
+            docker-tag: roundcube/roundcubemail:test-apache-nonroot
+            target: 'nonroot'
+          - variant: 'fpm'
+            test-files: 'fpm-postgres'
+            docker-tag: roundcube/roundcubemail:test-fpm-nonroot
+            target: 'nonroot'
+          - variant: 'fpm-alpine'
+            test-files: 'fpm-postgres'
+            docker-tag: roundcube/roundcubemail:test-fpm-alpine-nonroot
+            target: 'nonroot'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -40,7 +55,7 @@ jobs:
           password: ${{ secrets.DOCKER_PULL_PASSWORD }}
 
       - name: Build image for "${{ matrix.variant }}"
-        run: cd ${{ matrix.variant }} && docker buildx build ./ -t ${{ matrix.docker-tag }}
+        run: cd ${{ matrix.variant }} && docker buildx build ./ -t ${{ matrix.docker-tag }} --target ${{ matrix.target }}
       - name: Run tests
         env:
           ROUNDCUBEMAIL_TEST_IMAGE: ${{ matrix.docker-tag }}

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-apache
+FROM php:8.1-apache as root
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
@@ -113,7 +113,20 @@ RUN set -ex; \
 	rm -rf /usr/src/roundcubemail/installer; \
 	chown -R www-data:www-data /usr/src/roundcubemail/logs; \
 # Create the config dir
-	mkdir -p /var/roundcube/config /var/roundcube/enigma
+	mkdir -p /var/roundcube/config /var/roundcube/enigma; \
+	chown -R www-data:www-data /var/roundcube; \
+	chmod +t /var/roundcube
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["apache2-foreground"]
+
+
+#### non-root stage
+
+FROM root as nonroot
+
+# Prepare locale config for locale-gen
+RUN	echo "en_US.UTF-8 UTF-8" > /etc/locale.gen; \
+	/usr/sbin/locale-gen
+
+USER 33:33

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -189,9 +189,8 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   : "${ROUNDCUBEMAIL_LOCALE:=en_US.UTF-8 UTF-8}"
 
-  if [ -e /usr/sbin/locale-gen ] && [ ! -z "${ROUNDCUBEMAIL_LOCALE}" ]; then
-    echo "${ROUNDCUBEMAIL_LOCALE}" > /etc/locale.gen
-    /usr/sbin/locale-gen
+  if [ -e /usr/sbin/locale-gen ] && [ ! -f /etc/locale.gen ] && [ ! -z "${ROUNDCUBEMAIL_LOCALE}" ]; then
+    echo "${ROUNDCUBEMAIL_LOCALE}" > /etc/locale.gen && /usr/sbin/locale-gen
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_ASPELL_DICTS}" ]; then

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-alpine
+FROM php:8.1-fpm-alpine as root
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
@@ -107,7 +107,16 @@ RUN set -ex; \
 	rm -rf /usr/src/roundcubemail/installer; \
 	chown -R www-data:www-data /usr/src/roundcubemail/logs; \
 # Create the config dir
-	mkdir -p /var/roundcube/config /var/roundcube/enigma
+	mkdir -p /var/roundcube/config /var/roundcube/enigma; \
+	chown -R www-data:www-data /var/roundcube; \
+	chmod +t /var/roundcube
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["php-fpm"]
+
+
+#### non-root stage
+
+FROM root as nonroot
+
+USER 82:82

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -189,9 +189,8 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   : "${ROUNDCUBEMAIL_LOCALE:=en_US.UTF-8 UTF-8}"
 
-  if [ -e /usr/sbin/locale-gen ] && [ ! -z "${ROUNDCUBEMAIL_LOCALE}" ]; then
-    echo "${ROUNDCUBEMAIL_LOCALE}" > /etc/locale.gen
-    /usr/sbin/locale-gen
+  if [ -e /usr/sbin/locale-gen ] && [ ! -f /etc/locale.gen ] && [ ! -z "${ROUNDCUBEMAIL_LOCALE}" ]; then
+    echo "${ROUNDCUBEMAIL_LOCALE}" > /etc/locale.gen && /usr/sbin/locale-gen
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_ASPELL_DICTS}" ]; then

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.1-fpm as root
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
@@ -113,7 +113,20 @@ RUN set -ex; \
 	rm -rf /usr/src/roundcubemail/installer; \
 	chown -R www-data:www-data /usr/src/roundcubemail/logs; \
 # Create the config dir
-	mkdir -p /var/roundcube/config /var/roundcube/enigma
+	mkdir -p /var/roundcube/config /var/roundcube/enigma; \
+	chown -R www-data:www-data /var/roundcube; \
+	chmod +t /var/roundcube
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["php-fpm"]
+
+
+#### non-root stage
+
+FROM root as nonroot
+
+# Prepare locale config for locale-gen
+RUN	echo "en_US.UTF-8 UTF-8" > /etc/locale.gen; \
+	/usr/sbin/locale-gen
+
+USER 33:33

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -189,9 +189,8 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   : "${ROUNDCUBEMAIL_LOCALE:=en_US.UTF-8 UTF-8}"
 
-  if [ -e /usr/sbin/locale-gen ] && [ ! -z "${ROUNDCUBEMAIL_LOCALE}" ]; then
-    echo "${ROUNDCUBEMAIL_LOCALE}" > /etc/locale.gen
-    /usr/sbin/locale-gen
+  if [ -e /usr/sbin/locale-gen ] && [ ! -f /etc/locale.gen ] && [ ! -z "${ROUNDCUBEMAIL_LOCALE}" ]; then
+    echo "${ROUNDCUBEMAIL_LOCALE}" > /etc/locale.gen && /usr/sbin/locale-gen
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_ASPELL_DICTS}" ]; then

--- a/templates/Dockerfile-alpine.templ
+++ b/templates/Dockerfile-alpine.templ
@@ -1,4 +1,4 @@
-FROM php:8.1-%%VARIANT%%
+FROM php:8.1-%%VARIANT%% as root
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
@@ -107,7 +107,16 @@ RUN set -ex; \
 	rm -rf /usr/src/roundcubemail/installer; \
 	chown -R www-data:www-data /usr/src/roundcubemail/logs; \
 # Create the config dir
-	mkdir -p /var/roundcube/config /var/roundcube/enigma
+	mkdir -p /var/roundcube/config /var/roundcube/enigma; \
+	chown -R www-data:www-data /var/roundcube; \
+	chmod +t /var/roundcube
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["%%CMD%%"]
+
+
+#### non-root stage
+
+FROM root as nonroot
+
+USER 82:82

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -1,4 +1,4 @@
-FROM php:8.1-%%VARIANT%%
+FROM php:8.1-%%VARIANT%% as root
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
 
@@ -113,7 +113,20 @@ RUN set -ex; \
 	rm -rf /usr/src/roundcubemail/installer; \
 	chown -R www-data:www-data /usr/src/roundcubemail/logs; \
 # Create the config dir
-	mkdir -p /var/roundcube/config /var/roundcube/enigma
+	mkdir -p /var/roundcube/config /var/roundcube/enigma; \
+	chown -R www-data:www-data /var/roundcube; \
+	chmod +t /var/roundcube
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["%%CMD%%"]
+
+
+#### non-root stage
+
+FROM root as nonroot
+
+# Prepare locale config for locale-gen
+RUN	echo "en_US.UTF-8 UTF-8" > /etc/locale.gen; \
+	/usr/sbin/locale-gen
+
+USER 33:33

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -189,9 +189,8 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   : "${ROUNDCUBEMAIL_LOCALE:=en_US.UTF-8 UTF-8}"
 
-  if [ -e /usr/sbin/locale-gen ] && [ ! -z "${ROUNDCUBEMAIL_LOCALE}" ]; then
-    echo "${ROUNDCUBEMAIL_LOCALE}" > /etc/locale.gen
-    /usr/sbin/locale-gen
+  if [ -e /usr/sbin/locale-gen ] && [ ! -f /etc/locale.gen ] && [ ! -z "${ROUNDCUBEMAIL_LOCALE}" ]; then
+    echo "${ROUNDCUBEMAIL_LOCALE}" > /etc/locale.gen && /usr/sbin/locale-gen
   fi
 
   if [ ! -z "${ROUNDCUBEMAIL_ASPELL_DICTS}" ]; then


### PR DESCRIPTION
Adds an additional stage to the Dockerfile to create images with default user www-data. Publish as `roundcube/roundcubemail-nonroot` for distinction.

Execution of /usr/sbin/locale-gen won't work as non-root user and thus the locale is already set in the Docker image.

Refs: #306