### PR TITLE
Make apt not ask on upgrade

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemai
 # This should be done by the upstream images, but as long as they don't do it,
 # we rather use our own hands than suffer from outdated packages.
 # Kept as standalone command to make it stand out and be easy to remove.
-RUN apt-get update && apt-get upgrade && apt-get clean
+RUN apt-get update && apt-get -y upgrade && apt-get clean
 
 RUN set -ex; \
 	if [ "apache" = "apache" ]; then a2enmod rewrite; fi; \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemai
 # This should be done by the upstream images, but as long as they don't do it,
 # we rather use our own hands than suffer from outdated packages.
 # Kept as standalone command to make it stand out and be easy to remove.
-RUN apt-get update && apt-get upgrade && apt-get clean
+RUN apt-get update && apt-get -y upgrade && apt-get clean
 
 RUN set -ex; \
 	if [ "fpm" = "apache" ]; then a2enmod rewrite; fi; \

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemai
 # This should be done by the upstream images, but as long as they don't do it,
 # we rather use our own hands than suffer from outdated packages.
 # Kept as standalone command to make it stand out and be easy to remove.
-RUN apt-get update && apt-get upgrade && apt-get clean
+RUN apt-get update && apt-get -y upgrade && apt-get clean
 
 RUN set -ex; \
 	if [ "%%VARIANT%%" = "apache" ]; then a2enmod rewrite; fi; \


### PR DESCRIPTION
The need for package upgrade occurred last night ([example](https://github.com/roundcube/roundcubemail-docker/actions/runs/12739873927/job/35504227953), but failed due to apt expecting input.

This fixes that.