### PR TITLE
Remove problematic platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.variant }}
-          platforms: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/s390x,linux/ppc64le,linux/386,linux/amd64,"
+          platforms: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/amd64,"
           push: true
           tags: ${{ matrix.docker-tag }}
           # does not work linux/arm/v5 AND linux/mips64le - composer does not support  mips64le or armv5 nor does the php image support them on the alpine variant


### PR DESCRIPTION
The removed platforms [repeatedly](https://github.com/roundcube/roundcubemail-docker/actions/workflows/build-and-publish-nightly.yml) [caused](https://github.com/roundcube/roundcubemail-docker/actions/workflows/build.yml) building errors on the OS level (nothing we can fix).

Since they are pretty niche, too, I'm proposing to remove them.
