### PR TITLE
Make HTTP daemons use public_html/ as document root

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -8,7 +8,13 @@ LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemai
 RUN apt-get update && apt-get -y upgrade && apt-get clean
 
 RUN set -ex; \
-	if [ "apache" = "apache" ]; then a2enmod rewrite; fi; \
+	if [ "apache" = "apache" ]; then \
+		a2enmod rewrite; \
+		# Make Apache use public_html/ as document root to protect files outside of it \
+		# against unauthorized access. \
+		# This is possible and recommended since a while, and will be required for Roundcubemail v1.7. \
+		sed -i -e 's|\(DocumentRoot /var/www/html\)$|\1/public_html|' /etc/apache2/sites-available/000-default.conf; \
+	fi; \
 	apt-get update; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/examples/nginx/templates/default.conf.template
+++ b/examples/nginx/templates/default.conf.template
@@ -3,7 +3,7 @@ server {
     server_name php-docker.local;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
-    root /var/www/html;
+    root /var/www/html/public_html;
 
     location ~ /(temp|logs)/ {
         deny all;

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -8,7 +8,13 @@ LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemai
 RUN apt-get update && apt-get -y upgrade && apt-get clean
 
 RUN set -ex; \
-	if [ "fpm" = "apache" ]; then a2enmod rewrite; fi; \
+	if [ "fpm" = "apache" ]; then \
+		a2enmod rewrite; \
+		# Make Apache use public_html/ as document root to protect files outside of it \
+		# against unauthorized access. \
+		# This is possible and recommended since a while, and will be required for Roundcubemail v1.7. \
+		sed -i -e 's|\(DocumentRoot /var/www/html\)$|\1/public_html|' /etc/apache2/sites-available/000-default.conf; \
+	fi; \
 	apt-get update; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -13,6 +13,7 @@ RUN set -ex; \
 	mv /usr/src/roundcubemail-master /usr/src/roundcubemail; \
 	cd /usr/src/roundcubemail; \
 	rm -rf installer tests .ci .github .gitignore .editorconfig .tx .travis.yml; \
+	[ -f  public_html/installer.php ] && rm -f public_html/installer.php; \
 	make css-elastic; \
 	composer require kolab/net_ldap3 --no-install; \
 	composer require bjeavons/zxcvbn-php --no-install; \

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -12,7 +12,7 @@ RUN set -ex; \
 	rm roundcubemail.tar.gz; \
 	mv /usr/src/roundcubemail-master /usr/src/roundcubemail; \
 	cd /usr/src/roundcubemail; \
-	rm -rf installer tests public_html .ci .github .gitignore .editorconfig .tx .travis.yml; \
+	rm -rf installer tests .ci .github .gitignore .editorconfig .tx .travis.yml; \
 	make css-elastic; \
 	composer require kolab/net_ldap3 --no-install; \
 	composer require bjeavons/zxcvbn-php --no-install; \

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -8,7 +8,13 @@ LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemai
 RUN apt-get update && apt-get -y upgrade && apt-get clean
 
 RUN set -ex; \
-	if [ "%%VARIANT%%" = "apache" ]; then a2enmod rewrite; fi; \
+	if [ "%%VARIANT%%" = "apache" ]; then \
+		a2enmod rewrite; \
+		# Make Apache use public_html/ as document root to protect files outside of it \
+		# against unauthorized access. \
+		# This is possible and recommended since a while, and will be required for Roundcubemail v1.7. \
+		sed -i -e 's|\(DocumentRoot /var/www/html\)$|\1/public_html|' /etc/apache2/sites-available/000-default.conf; \
+	fi; \
 	apt-get update; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \


### PR DESCRIPTION
To protect files outside of the document root against unauthorized
access.
This is possible and recommended since a while, and will be required for
Roundcubemail v1.7.

This fixes the nightly builds.

Closes #319 and #320