### PR TITLE
Use php.ini-production as recommended by the upstream image authors

### DIFF
--- a/templates/Dockerfile-alpine.templ
+++ b/templates/Dockerfile-alpine.templ
@@ -77,6 +77,9 @@ RUN set -ex; \
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
+# Use the default production configuration
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
 # use custom PHP settings
 COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -84,6 +84,9 @@ RUN set -ex; \
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
+# Use the default production configuration
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
 # use custom PHP settings
 COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 


### PR DESCRIPTION
https://hub.docker.com/_/php says:

> It is strongly recommended to use the production config for images used in production environments!

So we better do that!

The settings are pretty sensible, I think it's not risky and not a breaking change to merge this.