### PR TITLE
Reduce platforms for nightly builds, too

### DIFF
--- a/.github/workflows/build-and-publish-nightly.yml
+++ b/.github/workflows/build-and-publish-nightly.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: nightly
-          platforms: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/s390x,linux/ppc64le,linux/386,linux/amd64,"
+          platforms: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/amd64,"
           push: true
           tags: roundcube/roundcubemail:nightly
           # does not work linux/arm/v5 AND linux/mips64le - composer does not support  mips64le or armv5 nor does the php image support them on the alpine variant


### PR DESCRIPTION
In #314 I forgot the nightlies, which this catches up with.