### PR TITLE
Pin GitHub Actions to specific commits

### DIFF
--- a/.github/workflows/bot-create-manual-reminder.yml
+++ b/.github/workflows/bot-create-manual-reminder.yml
@@ -15,4 +15,4 @@ jobs:
 
     steps:
       - name: 👀 check for reminder
-        uses: agrc/create-reminder-action@v1
+        uses: agrc/create-reminder-action@9ff30cde74284045941af16a04362938957253b1 # v1.1.17

--- a/.github/workflows/bot-manual-reminder.yml
+++ b/.github/workflows/bot-manual-reminder.yml
@@ -15,4 +15,4 @@ jobs:
 
     steps:
       - name: check reminders and notify
-        uses: agrc/reminder-action@v1
+        uses: agrc/reminder-action@96f2ec2e1a7a53ead156504922e9bc36d64f49ee # v1.0.16

--- a/.github/workflows/bot-remind-stale-pull-requests.yml
+++ b/.github/workflows/bot-remind-stale-pull-requests.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'roundcube/roundcubemail-docker'
     runs-on: ubuntu-latest
     steps:
-      - uses: sojusan/github-action-reminder@v1
+      - uses: sojusan/github-action-reminder@85a7d4ea6d5535e88e47baa242918a6a654de65d # v1.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reminder_message: "🛎️ This PR has had no activity in two weeks."

--- a/.github/workflows/build-and-publish-nightly.yml
+++ b/.github/workflows/build-and-publish-nightly.yml
@@ -14,26 +14,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get docker hub username
         id: creds
         run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
       - name: Login to Docker Hub
         if: steps.creds.outputs.username != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_PULL_USERNAME }}
           password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
           buildkitd-flags: --debug
 
       - name: Build and push nightly image"
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: nightly
           platforms: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/amd64,"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,26 +40,26 @@ jobs:
             test-tag: roundcube/roundcubemail:latest-fpm-alpine
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get docker hub username
         id: creds
         run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
       - name: Login to Docker Hub
         if: steps.creds.outputs.username != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_PULL_USERNAME }}
           password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
         with:
           buildkitd-flags: --debug
 
       - name: Build and push image for "${{ matrix.variant }}"
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: ${{ matrix.variant }}
           platforms: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/amd64,"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,13 @@ jobs:
             docker-tag: roundcube/roundcubemail:test-fpm-alpine
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get docker hub username
         id: creds
         run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
       - name: Login to Docker Hub
         if: steps.creds.outputs.username != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKER_PULL_USERNAME }}
           password: ${{ secrets.DOCKER_PULL_PASSWORD }}

--- a/.github/workflows/update-sh.yml
+++ b/.github/workflows/update-sh.yml
@@ -18,7 +18,7 @@ jobs:
     name: Run update.sh script
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         token: ${{ secrets.WOKFLOW_TOKEN }}
     - name: Run update.sh script


### PR DESCRIPTION
This is motivated by a recent case in which a github action was compromised and manipulated tags to point to malicious code <https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised>.