### PR TITLE
Fix non-root-images for RC 1.7.x

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -139,6 +139,7 @@ RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen; \
 	/usr/sbin/locale-gen
 
 RUN sed -i 's/^Listen 80$/Listen 8000/' /etc/apache2/ports.conf
+RUN sed -i /etc/apache2/sites-enabled/000-default.conf -e 's/:80>/:8000>/'
 
 EXPOSE 8000
 

--- a/apache/nonroot-add.txt
+++ b/apache/nonroot-add.txt
@@ -1,3 +1,4 @@
 RUN sed -i 's/^Listen 80$/Listen 8000/' /etc/apache2/ports.conf
+RUN sed -i /etc/apache2/sites-enabled/000-default.conf -e 's/:80>/:8000>/'
 
 EXPOSE 8000


### PR DESCRIPTION
Previously the Apache was using /var/www/html as docroot, because the VirtualHost was matching port 80 only.

This ~~might also fix~~ also fixes the errors from testing the builds ([1](https://github.com/roundcube/roundcubemail-docker/actions/runs/14566611428/job/40856821807), [2](https://github.com/roundcube/roundcubemail-docker/actions/runs/14566611428/job/40856821805), [3](https://github.com/roundcube/roundcubemail-docker/actions/runs/14566611428/job/40856821810)).