### PR TITLE
Refresh apt-cache before installing aspell dictionaries

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -195,7 +195,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   if [ ! -z "${ROUNDCUBEMAIL_ASPELL_DICTS}" ]; then
     ASPELL_PACKAGES=`echo -n "aspell-${ROUNDCUBEMAIL_ASPELL_DICTS}" | sed -E "s/[, ]+/ aspell-/g"`
-    which apt-get && apt-get install -y $ASPELL_PACKAGES
+    which apt-get && apt-get update && apt-get install -y $ASPELL_PACKAGES
     which apk && apk add --no-cache $ASPELL_PACKAGES
   fi
 

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -195,7 +195,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   if [ ! -z "${ROUNDCUBEMAIL_ASPELL_DICTS}" ]; then
     ASPELL_PACKAGES=`echo -n "aspell-${ROUNDCUBEMAIL_ASPELL_DICTS}" | sed -E "s/[, ]+/ aspell-/g"`
-    which apt-get && apt-get install -y $ASPELL_PACKAGES
+    which apt-get && apt-get update && apt-get install -y $ASPELL_PACKAGES
     which apk && apk add --no-cache $ASPELL_PACKAGES
   fi
 

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -195,7 +195,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   if [ ! -z "${ROUNDCUBEMAIL_ASPELL_DICTS}" ]; then
     ASPELL_PACKAGES=`echo -n "aspell-${ROUNDCUBEMAIL_ASPELL_DICTS}" | sed -E "s/[, ]+/ aspell-/g"`
-    which apt-get && apt-get install -y $ASPELL_PACKAGES
+    which apt-get && apt-get update && apt-get install -y $ASPELL_PACKAGES
     which apk && apk add --no-cache $ASPELL_PACKAGES
   fi
 

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -195,7 +195,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
 
   if [ ! -z "${ROUNDCUBEMAIL_ASPELL_DICTS}" ]; then
     ASPELL_PACKAGES=`echo -n "aspell-${ROUNDCUBEMAIL_ASPELL_DICTS}" | sed -E "s/[, ]+/ aspell-/g"`
-    which apt-get && apt-get install -y $ASPELL_PACKAGES
+    which apt-get && apt-get update && apt-get install -y $ASPELL_PACKAGES
     which apk && apk add --no-cache $ASPELL_PACKAGES
   fi
 


### PR DESCRIPTION
the Debian-based images have the apt-cache (`/var/lib/apt/`) purged, so we cannot simply issue an `apt-get install` in the https://github.com/roundcube/roundcubemail-docker/blob/a62e4b6f483fccd035dd9d4db71e85ca1bf4d4a0/templates/docker-entrypoint.sh#L198

instead we have to call `apt-get update` first.

this is different from alpine, where `apk add` will implicitly refresh the cache first.


Closes: https://github.com/roundcube/roundcubemail-docker/issues/334