### PR TITLE
Fix build.yml for nonroot images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,14 @@ jobs:
             docker-tag: roundcube/roundcubemail:1.6.x-apache-nonroot,roundcube/roundcubemail:1.6.10-apache-nonroot,roundcube/roundcubemail:latest-apache-nonroot,roundcube/roundcubemail:latest-nonroot
             test-tag: roundcube/roundcubemail:latest-apache-nonroot
             target: 'nonroot'
+            http-port: '8000'
           - variant: 'fpm'
-            test-files: 'apache-postgres'
+            test-files: 'fpm-postgres'
             docker-tag: roundcube/roundcubemail:1.6.x-fpm-nonroot,roundcube/roundcubemail:1.6.10-fpm-nonroot,roundcube/roundcubemail:latest-fpm-nonroot
             test-tag: roundcube/roundcubemail:latest-fpm-nonroot
             target: 'nonroot'
           - variant: 'fpm-alpine'
-            test-files: 'apache-postgres'
+            test-files: 'fpm-postgres'
             docker-tag: roundcube/roundcubemail:1.6.x-fpm-alpine-nonroot,roundcube/roundcubemail:1.6.10-fpm-alpine-nonroot,roundcube/roundcubemail:latest-fpm-alpine-nonroot
             test-tag: roundcube/roundcubemail:latest-fpm-alpine-nonroot
             target: 'nonroot'
@@ -89,6 +90,7 @@ jobs:
       - name: Run tests
         env:
           ROUNDCUBEMAIL_TEST_IMAGE: ${{ matrix.test-tag }}
+          HTTP_PORT: ${{ matrix.http-port || '80' }}
         run: |
           set -exu;
           for testFile in ${{ join(matrix.test-files, ' ') }};


### PR DESCRIPTION
Copying the correct details from test.yml, they were just overlooked in build.yml