### PR TITLE
Separate workflow for development image

### DIFF
--- a/.github/workflows/build-and-publish-development.yml
+++ b/.github/workflows/build-and-publish-development.yml
@@ -1,0 +1,77 @@
+name: Build & publish development image
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'development/**'
+      - .github/workflows/*-development.yml
+  schedule:
+    # Rebuild images each monday morning to ensure a fresh base OS (but later than the main image building workflow,
+    # because the development image builds on one of them)
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+jobs:
+  build_test_publish:
+    name: Build, test and publish image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Docker
+        # This step is required to enable the containerd image store, which is required by the cache type=gha
+        uses: docker/setup-docker-action@b60f85385d03ac8acfca6d9996982511d8620a19 # v4.3.0
+        with:
+          daemon-config: |
+           {
+             "debug": true,
+             "features": {
+               "containerd-snapshotter": true
+             }
+           }
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        with:
+          buildkitd-flags: --debug
+
+      - name: Build development image for tests"
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: development
+          load: true
+          tags: roundcube/roundcubemail:development
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test built image
+        env:
+          ROUNDCUBEMAIL_TEST_IMAGE: roundcube/roundcubemail:development
+        run: ./development/test.sh
+
+      # Only log into docker now, so we benefit from the automatic caching of upstream images.
+      - name: Get docker hub username
+        id: creds
+        run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
+      - name: Login to Docker Hub
+        if: steps.creds.outputs.username != ''
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKER_PULL_USERNAME }}
+          password: ${{ secrets.DOCKER_PUSH_PASSWORD }}
+
+      - name: Build and push development images for all platforms
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: development
+          platforms: "linux/arm64,linux/arm/v6,linux/arm/v7,linux/386,linux/amd64"
+          push: true
+          tags: roundcube/roundcubemail:development
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ on:
       - 'fpm-1.5.x/**'
       - 'fpm-alpine-1.5.x/**'
       - '.github/workflows/*-1.5.yml'
+      - 'development/**'
+      - 'nightly/**'
     tags:
       - '1.6.*'
   schedule:
@@ -71,10 +73,6 @@ jobs:
             test-tag: roundcube/roundcubemail:latest-fpm-alpine
             test-tag-nonroot: roundcube/roundcubemail:latest-fpm-alpine-nonroot
             target: 'root'
-          - variant: 'development'
-            test-files: 'development'
-            docker-tag: roundcube/roundcubemail:development
-            test-tag: roundcube/roundcubemail:development
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test-development.yml
+++ b/.github/workflows/test-development.yml
@@ -1,0 +1,30 @@
+name: Build & test development image
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+      paths:
+          - "development/**"
+          - ".github/workflows/*-development.yml"
+
+jobs:
+  build-and-test:
+    name: Build and test development image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build development image for tests"
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: development
+          load: true
+          tags: roundcube/roundcubemail:development
+
+      - name: Test built image
+        env:
+          ROUNDCUBEMAIL_TEST_IMAGE: roundcube/roundcubemail:development
+        run: ./development/test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,13 @@ permissions:
   contents: read
 
 on:
-  pull_request: {}
-  push:
-    branches:
-      - '!master'
+  pull_request:
     paths-ignore:
+      - "development/**"
+      - .github/workflows/*-development.yml
+      - "nightly/**"
+      - "examples/**"
+      - "README.md"
       - apache-1.5.x/**
       - fpm-1.5.x/**
       - fpm-alpine-1.5.x/**

--- a/development/test.sh
+++ b/development/test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+EXPECTED_STRING='Error: No source code in /var/www/html – you must mount your code base to that path!'
+
+ContID="$(docker run -d roundcube/roundcubemail:development)"
+sleep 5
+
+if $(docker logs $ContID 2>&1 | grep -q "$EXPECTED_STRING"); then
+    docker rm -f $ContID 2>&1 >/dev/null
+    echo "✅ Test successful "
+    exit 0
+fi
+
+echo "⚠️ Error: The container output did not contain the expected string '$EXPECTED_STRING', the test failed!"
+echo "Container output:"
+docker logs $ContID
+
+docker rm -f $ContID 2>&1 >/dev/null
+exit 1


### PR DESCRIPTION
It needs different testing than the main images, thus we use standalone workflows.

This also makes the main workflows ignore changes in development/ and nightly/