### PR TITLE
Build/test only 1.5 images on changes to 1.5 workflows

### DIFF
--- a/.github/workflows/build-1.5.yml
+++ b/.github/workflows/build-1.5.yml
@@ -11,6 +11,7 @@ on:
       - 'apache-1.5.x/**'
       - 'fpm-1.5.x/**'
       - 'fpm-alpine-1.5.x/**'
+      - '.github/workflows/*-1.5.yml'
 
   schedule:
     # Rebuild images each monday early morning to ensure a fresh base OS.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ on:
       - 'apache-1.5.x/**'
       - 'fpm-1.5.x/**'
       - 'fpm-alpine-1.5.x/**'
+      - '.github/workflows/*-1.5.yml'
     tags:
       - '1.6.*'
   schedule:

--- a/.github/workflows/test-1.5.yml
+++ b/.github/workflows/test-1.5.yml
@@ -12,6 +12,7 @@ on:
       - apache-1.5.x/**
       - fpm-1.5.x/**
       - fpm-alpin-1.5.x/**
+      - '.github/workflows/*-1.5.yml'
 
 jobs:
   build-and-testvariants:


### PR DESCRIPTION
On changes to .github/workflow/*-1.5.yml only the 1.5 images should be tested and/or built.