### PR TITLE
Add ROUNDCUBEMAIL_MAIL_DOMAIN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The following env variables can be set to configure your Roundcube Docker instan
 
 `ROUNDCUBEMAIL_USERNAME_DOMAIN` - Automatically add this domain to user names for login. See [defaults.inc.php](https://github.com/roundcube/roundcubemail/blob/master/config/defaults.inc.php) for more information.
 
+`ROUNDCUBEMAIL_MAIL_DOMAIN` - This domain will be used to form e-mail addresses of new users. See [defaults.inc.php](https://github.com/roundcube/roundcubemail/blob/master/config/defaults.inc.php) for more information.
+
 `ROUNDCUBEMAIL_REQUEST_PATH` - Specify request path with reverse proxy; defaults to `/`. See [defaults.inc.php](https://github.com/roundcube/roundcubemail/blob/master/config/defaults.inc.php) for possible values.
 
 `ROUNDCUBEMAIL_PLUGINS` - List of built-in plugins to activate. Defaults to `archive,zipdownload`

--- a/apache-1.5.x/docker-entrypoint.sh
+++ b/apache-1.5.x/docker-entrypoint.sh
@@ -99,6 +99,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   \$config['default_port'] = '${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_server'] = '${ROUNDCUBEMAIL_SMTP_SERVER}';
   \$config['smtp_port'] = '${ROUNDCUBEMAIL_SMTP_PORT}';
+  \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
+  \$config['mail_domain'] = '${ROUNDCUBEMAIL_MAIL_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['plugins'] = array_filter(array_unique(array_merge(\$config['plugins'], ['${ROUNDCUBEMAIL_PLUGINS_PHP}'])));

--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -152,6 +152,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   \$config['imap_host'] = '${ROUNDCUBEMAIL_DEFAULT_HOST}:${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
   \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
+  \$config['mail_domain'] = '${ROUNDCUBEMAIL_MAIL_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['request_path'] = '${ROUNDCUBEMAIL_REQUEST_PATH}';

--- a/fpm-1.5.x/docker-entrypoint.sh
+++ b/fpm-1.5.x/docker-entrypoint.sh
@@ -99,6 +99,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   \$config['default_port'] = '${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_server'] = '${ROUNDCUBEMAIL_SMTP_SERVER}';
   \$config['smtp_port'] = '${ROUNDCUBEMAIL_SMTP_PORT}';
+  \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
+  \$config['mail_domain'] = '${ROUNDCUBEMAIL_MAIL_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['plugins'] = array_filter(array_unique(array_merge(\$config['plugins'], ['${ROUNDCUBEMAIL_PLUGINS_PHP}'])));

--- a/fpm-alpine-1.5.x/docker-entrypoint.sh
+++ b/fpm-alpine-1.5.x/docker-entrypoint.sh
@@ -99,6 +99,8 @@ if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
   \$config['default_port'] = '${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_server'] = '${ROUNDCUBEMAIL_SMTP_SERVER}';
   \$config['smtp_port'] = '${ROUNDCUBEMAIL_SMTP_PORT}';
+  \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
+  \$config['mail_domain'] = '${ROUNDCUBEMAIL_MAIL_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['plugins'] = array_filter(array_unique(array_merge(\$config['plugins'], ['${ROUNDCUBEMAIL_PLUGINS_PHP}'])));

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -152,6 +152,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   \$config['imap_host'] = '${ROUNDCUBEMAIL_DEFAULT_HOST}:${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
   \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
+  \$config['mail_domain'] = '${ROUNDCUBEMAIL_MAIL_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['request_path'] = '${ROUNDCUBEMAIL_REQUEST_PATH}';

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -152,6 +152,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   \$config['imap_host'] = '${ROUNDCUBEMAIL_DEFAULT_HOST}:${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
   \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
+  \$config['mail_domain'] = '${ROUNDCUBEMAIL_MAIL_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['request_path'] = '${ROUNDCUBEMAIL_REQUEST_PATH}';

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -152,6 +152,7 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   \$config['imap_host'] = '${ROUNDCUBEMAIL_DEFAULT_HOST}:${ROUNDCUBEMAIL_DEFAULT_PORT}';
   \$config['smtp_host'] = '${ROUNDCUBEMAIL_SMTP_SERVER}:${ROUNDCUBEMAIL_SMTP_PORT}';
   \$config['username_domain'] = '${ROUNDCUBEMAIL_USERNAME_DOMAIN}';
+  \$config['mail_domain'] = '${ROUNDCUBEMAIL_MAIL_DOMAIN}';
   \$config['temp_dir'] = '${ROUNDCUBEMAIL_TEMP_DIR}';
   \$config['skin'] = '${ROUNDCUBEMAIL_SKIN}';
   \$config['request_path'] = '${ROUNDCUBEMAIL_REQUEST_PATH}';


### PR DESCRIPTION
Fixes #231, it is a complementary PR for the #240 which tried to fix the same issue.

Added `ROUNDCUBEMAIL_MAIL_DOMAIN` which sets the `mail_domain` config option.

I think this could be useful for people whose mail domain isn't the same as the IMAP server hostname (which is really common).

In @The-HEAD words:

> Current Situation:
> ROUNDCUBEMAIL_USERNAME_DOMAIN = mail.example.com will add this to the username upon loging in, meaning it will try to log into the mailserver with "[username@mail.example.com](mailto:username@mail.example.com)" which might be wrong.
> 
> What was requested is to have ROUNDCUBEMAIL_MAIL_DOMAIN = example.com or ROUNDCUBEMAIL_MAIL_DOMAIN = %d , specifying the mail domain AFTER login, so that the login is with "username" and then the email is "[username@example.com](mailto:username@example.com)".

Any thoughts on this? @thomascube @Clemenk