### PR TITLE
Also tear down volumes before building images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,8 +112,8 @@ jobs:
           set -exu;
           for testFile in ${{ join(matrix.test-files, ' ') }};
           do
-            docker compose -f ./tests/docker-compose.test-${testFile}.yml \
-            up --exit-code-from=sut --abort-on-container-exit
+            docker compose -f ./tests/docker-compose.test-${testFile}.yml down -v
+            docker compose -f ./tests/docker-compose.test-${testFile}.yml up --exit-code-from=sut --abort-on-container-exit
           done
 
       # Only log into docker now, so we benefit from the automatic caching of upstream images.
@@ -156,8 +156,8 @@ jobs:
           set -exu;
           for testFile in ${{ join(matrix.test-files, ' ') }};
           do
-            docker compose -f ./tests/docker-compose.test-${testFile}.yml \
-            up --exit-code-from=sut --abort-on-container-exit
+            docker compose -f ./tests/docker-compose.test-${testFile}.yml down -v
+            docker compose -f ./tests/docker-compose.test-${testFile}.yml up --exit-code-from=sut --abort-on-container-exit
           done
 
       - name: Build and push nonroot images for "${{ matrix.variant }} for all platforms"


### PR DESCRIPTION
Same as was introduced in efb91c27efdc282e39e286143eeb9046cf5e5d3a for testing images