### PR TITLE
raise severity of non-empty docroot test

### DIFF
--- a/apache/docker-entrypoint.sh
+++ b/apache/docker-entrypoint.sh
@@ -36,11 +36,13 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   INSTALLDIR=`pwd`
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
-    echo >&2 "roundcubemail not found in $PWD - copying now..."
-    if [ "$(ls -A)" ]; then
-      echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
-      ( set -x; ls -A; sleep 10 )
+    if [ -z "${SKIP_CHECK_EMPTY_DOCROOT}" ]; then
+      if find . -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+        echo >&2 "ERROR: $PWD is not empty; export SKIP_CHECK_EMPTY_DOCROOT=yes to ignore this"
+        exit 1
+      fi
     fi
+    echo >&2 "roundcubemail not found in $PWD - copying now..."
     tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $INSTALLDIR"
   # update Roundcube in docroot

--- a/fpm-alpine/docker-entrypoint.sh
+++ b/fpm-alpine/docker-entrypoint.sh
@@ -36,11 +36,13 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   INSTALLDIR=`pwd`
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
-    echo >&2 "roundcubemail not found in $PWD - copying now..."
-    if [ "$(ls -A)" ]; then
-      echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
-      ( set -x; ls -A; sleep 10 )
+    if [ -z "${SKIP_CHECK_EMPTY_DOCROOT}" ]; then
+      if find . -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+        echo >&2 "ERROR: $PWD is not empty; export SKIP_CHECK_EMPTY_DOCROOT=yes to ignore this"
+        exit 1
+      fi
     fi
+    echo >&2 "roundcubemail not found in $PWD - copying now..."
     tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $INSTALLDIR"
   # update Roundcube in docroot

--- a/fpm/docker-entrypoint.sh
+++ b/fpm/docker-entrypoint.sh
@@ -36,11 +36,13 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   INSTALLDIR=`pwd`
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
-    echo >&2 "roundcubemail not found in $PWD - copying now..."
-    if [ "$(ls -A)" ]; then
-      echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
-      ( set -x; ls -A; sleep 10 )
+    if [ -z "${SKIP_CHECK_EMPTY_DOCROOT}" ]; then
+      if find . -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+        echo >&2 "ERROR: $PWD is not empty; export SKIP_CHECK_EMPTY_DOCROOT=yes to ignore this"
+        exit 1
+      fi
     fi
+    echo >&2 "roundcubemail not found in $PWD - copying now..."
     tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $INSTALLDIR"
   # update Roundcube in docroot

--- a/templates/docker-entrypoint.sh
+++ b/templates/docker-entrypoint.sh
@@ -36,11 +36,13 @@ if  [[ "$1" == apache2* || "$1" == php-fpm || "$1" == bin* ]]; then
   INSTALLDIR=`pwd`
   # docroot is empty
   if ! [ -e index.php -a -e bin/installto.sh ]; then
-    echo >&2 "roundcubemail not found in $PWD - copying now..."
-    if [ "$(ls -A)" ]; then
-      echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
-      ( set -x; ls -A; sleep 10 )
+    if [ -z "${SKIP_CHECK_EMPTY_DOCROOT}" ]; then
+      if find . -mindepth 1 -maxdepth 1 -print -quit | grep -q .; then
+        echo >&2 "ERROR: $PWD is not empty; export SKIP_CHECK_EMPTY_DOCROOT=yes to ignore this"
+        exit 1
+      fi
     fi
+    echo >&2 "roundcubemail not found in $PWD - copying now..."
     tar cf - --one-file-system -C /usr/src/roundcubemail . | tar xf -
     echo >&2 "Complete! ROUNDCUBEMAIL has been successfully copied to $INSTALLDIR"
   # update Roundcube in docroot


### PR DESCRIPTION
previously, if the docroot was non-empty, the entrypoint script would wait for 10 seconds and then continue.

now, it will simply fail.
*unless* the `SKIP_CHECK_EMPTY_DOCROOT` envvar is set to some non-empty value.

this is a somewhat "breaking change", as people with half-popuplated docroots (e.g. having an local skin; like me) will now experience failures, unless they manually add the `SKIP_CHECK_EMPTY_DOCROOT` envvar to their setup.

- Closes: https://github.com/roundcube/roundcubemail-docker/issues/384