### PR TITLE
Use the non-privileged port in examples/docker-compose-nonroot

### DIFF
--- a/examples/docker-compose-nonroot.yaml
+++ b/examples/docker-compose-nonroot.yaml
@@ -6,7 +6,7 @@ services:
       - ./db/sqlite:/var/roundcube/db
       - ./nonroot-custom-php-config.ini:/usr/local/etc/php/conf.d/nonroot-custom-php-config.ini
     ports:
-      - 9003:80
+      - 9003:8000
     environment:
       - ROUNDCUBEMAIL_DEFAULT_HOST=tls://mail.example.org
       - ROUNDCUBEMAIL_SMTP_SERVER=tls://mail.example.org


### PR DESCRIPTION
In the nonroot image the web server listens to [port 8000, not 80](https://github.com/roundcube/roundcubemail-docker/blob/4d50ae1d37e0d0dcd2992cc7c8649d17c028068c/apache/nonroot-add.txt).
However, the respective docker-compose manifest example erroneously maps to internal port 80.
This change updates the manifest example with the correct internal port.