### PR TITLE
Rename nonroot-custom-php-config to apply last

### DIFF
--- a/examples/docker-compose-nonroot.yaml
+++ b/examples/docker-compose-nonroot.yaml
@@ -4,7 +4,7 @@ services:
     container_name: roundcubemail
     volumes:
       - ./db/sqlite:/var/roundcube/db
-      - ./nonroot-custom-php-config.ini:/usr/local/etc/php/conf.d/nonroot-custom-php-config.ini
+      - ./nonroot-custom-php-config.ini:/usr/local/etc/php/conf.d/zzz-nonroot-custom-php-config.ini
     ports:
       - 9003:80
     environment:


### PR DESCRIPTION
The docker-compose manifest example for the nonroot image mounts `nonroot-custom-php-config.ini` to `/usr/local/etc/php/conf.d/` to enable customizing the php configuration using an external file. However, files inside that folder are loaded in lexicographical order and a variable's effective value is determined by the last assigning statement. As a result, any variable values set in `roundcube-defaults.ini` override values set by the above file as demonstrated below:
```
$ docker exec -it roundcubemail /bin/bash -c "grep upload_max_filesize /usr/local/etc/php/conf.d/*; php -i | grep ^upload_max_filesize"
/usr/local/etc/php/conf.d/nonroot-custom-php-config.ini:upload_max_filesize=25M
/usr/local/etc/php/conf.d/roundcube-defaults.ini:upload_max_filesize=5M
upload_max_filesize => 5M => 5M
```

Instead, external ini file overrides should be loaded *after* roundcube defaults.

This change renames `nonroot-custom-php-config.ini` so that it loads after `roundcube-defaults.ini`.
```
$ docker exec -it roundcubemail /bin/bash -c "grep upload_max_filesize /usr/local/etc/php/conf.d/*; php -i | grep ^upload_max_filesize"
/usr/local/etc/php/conf.d/roundcube-defaults.ini:upload_max_filesize=5M
/usr/local/etc/php/conf.d/zzz-nonroot-custom-php-config.ini:upload_max_filesize=25M
upload_max_filesize => 25M => 25M
```