### PR TITLE
Update postgres examples to be 18+ compatible

### DIFF
--- a/examples/docker-compose-fpm-alpine.yaml
+++ b/examples/docker-compose-fpm-alpine.yaml
@@ -26,7 +26,7 @@ services:
     container_name: roundcubedb
     # restart: unless-stopped
     volumes:
-      - ./db/postgres:/var/lib/postgresql/data
+      - ./db/postgres:/var/lib/postgresql
     environment:
       - POSTGRES_DB=roundcube
       - POSTGRES_USER=roundcube

--- a/examples/docker-compose-fpm-alpine.yaml
+++ b/examples/docker-compose-fpm-alpine.yaml
@@ -26,7 +26,7 @@ services:
     container_name: roundcubedb
     # restart: unless-stopped
     volumes:
-      - ./db/postgres:/var/lib/postgresql
+      - ./db/postgres:/var/lib/postgresql # for postgres versions <18 use /var/lib/postgresql/data
     environment:
       - POSTGRES_DB=roundcube
       - POSTGRES_USER=roundcube

--- a/examples/docker-compose-fpm.yaml
+++ b/examples/docker-compose-fpm.yaml
@@ -26,7 +26,7 @@ services:
     container_name: roundcubedb
     # restart: unless-stopped
     volumes:
-      - ./db/postgres:/var/lib/postgresql/data
+      - ./db/postgres:/var/lib/postgresql
     environment:
       - POSTGRES_DB=roundcube
       - POSTGRES_USER=roundcube

--- a/examples/docker-compose-fpm.yaml
+++ b/examples/docker-compose-fpm.yaml
@@ -26,7 +26,7 @@ services:
     container_name: roundcubedb
     # restart: unless-stopped
     volumes:
-      - ./db/postgres:/var/lib/postgresql
+      - ./db/postgres:/var/lib/postgresql # for postgres versions <18 use /var/lib/postgresql/data
     environment:
       - POSTGRES_DB=roundcube
       - POSTGRES_USER=roundcube

--- a/examples/kubernetes.yaml
+++ b/examples/kubernetes.yaml
@@ -114,7 +114,7 @@ spec:
         ports:
         - containerPort: 5432
         volumeMounts:
-        - mountPath: /var/lib/postgresql/data
+        - mountPath: /var/lib/postgresql
           name: roundcubedb-volume
       restartPolicy: Always
       serviceAccountName: ""

--- a/examples/kubernetes.yaml
+++ b/examples/kubernetes.yaml
@@ -114,7 +114,7 @@ spec:
         ports:
         - containerPort: 5432
         volumeMounts:
-        - mountPath: /var/lib/postgresql
+        - mountPath: /var/lib/postgresql # for postgres versions <18 use /var/lib/postgresql/data
           name: roundcubedb-volume
       restartPolicy: Always
       serviceAccountName: ""


### PR DESCRIPTION
When starting the postgres examples, users are met with an error from the postgres container stating that the volume should be changed.

See https://github.com/docker-library/postgres/pull/1259 for details