### PR TITLE
Workflows: avoid deprecated set-output

### DIFF
--- a/.github/workflows/build-1.5.yml
+++ b/.github/workflows/build-1.5.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get docker hub username
         id: creds
-        run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
+        run: echo 'username=${{ secrets.DOCKER_PULL_USERNAME }}' >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         if: steps.creds.outputs.username != ''
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/build-and-publish-development.yml
+++ b/.github/workflows/build-and-publish-development.yml
@@ -58,7 +58,7 @@ jobs:
       # Only log into docker now, so we benefit from the automatic caching of upstream images.
       - name: Get docker hub username
         id: creds
-        run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
+        run: echo 'username=${{ secrets.DOCKER_PULL_USERNAME }}' >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         if: steps.creds.outputs.username != ''
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/build-and-publish-nightly.yml
+++ b/.github/workflows/build-and-publish-nightly.yml
@@ -51,7 +51,7 @@ jobs:
       # Only log into docker now, so we benefit from the automatic caching of upstream images.
       - name: Get docker hub username
         id: creds
-        run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
+        run: echo 'username=${{ secrets.DOCKER_PULL_USERNAME }}' >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         if: steps.creds.outputs.username != ''
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
       # Only log into docker now, so we benefit from the automatic caching of upstream images.
       - name: Get docker hub username
         id: creds
-        run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
+        run: echo 'username=${{ secrets.DOCKER_PULL_USERNAME }}' >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         if: steps.creds.outputs.username != ''
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/test-1.5.yml
+++ b/.github/workflows/test-1.5.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get docker hub username
         id: creds
-        run: echo '::set-output name=username::${{ secrets.DOCKER_PULL_USERNAME }}'
+        run: echo 'username=${{ secrets.DOCKER_PULL_USERNAME }}' >> $GITHUB_OUTPUT
       - name: Login to Docker Hub
         if: steps.creds.outputs.username != ''
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0


### PR DESCRIPTION
`set-output` has been deprecated for a long time (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), and when running there are warnings that the functionality will be removed soon:

> The `set-output` command is deprecated and will be disabled soon.

(For example here: https://github.com/roundcube/roundcubemail-docker/actions/runs/24817533546/job/72634912782)

Another thing is that many of the actions used are outdated and are based on Node 20, which is deprecated as well and will stop working later this year. Out of curiosity, why not use Dependabot to automatically update the actions from time to time?