### PR TITLE
Add Dependabot config for updating GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Do updates once per week (on Monday)
+      interval: "weekly"
+    groups:
+      # Make sure that a single PR is created for all GH Action updates.
+      # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+      ci:
+        patterns:
+          - "*"


### PR DESCRIPTION
Similar to https://github.com/getsops/sops/blob/main/.github/dependabot.yaml, which I've been using successfully for some time now.

I set the interval to once per week. If this is too frequent, this can also be set to `monthly` or `quarterly`.

I'm not sure whether Dependabot will run directly once this is merged, or whether you have to wait for the scheduled point in time. It should be possible to force a run now this way: https://stackoverflow.com/a/77502174