### PR TITLE
Provide the Roundcubemail version as container image label

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,6 +1,16 @@
 FROM php:8.4-apache AS root
+
+# Define Roundcubemail version
+# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
+# environment.
+ARG ROUNDCUBEMAIL_VERSION=1.7.1
+
+# Define the GPG key used for the bundle verification process
+ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
+
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
+LABEL org.opencontainers.image.version="${ROUNDCUBEMAIL_VERSION}"
 
 # This should be done by the upstream images, but as long as they don't do it,
 # we rather use our own hands than suffer from outdated packages.
@@ -99,14 +109,6 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 
 COPY --chmod=0755 docker-entrypoint.sh /
-
-# Define Roundcubemail version
-# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
-# environment.
-ARG ROUNDCUBEMAIL_VERSION=1.7.1
-
-# Define the GPG key used for the bundle verification process
-ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -1,6 +1,16 @@
 FROM php:8.4-fpm-alpine3.21 AS root
+
+# Define Roundcubemail version
+# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
+# environment.
+ARG ROUNDCUBEMAIL_VERSION=1.7.1
+
+# Define the GPG key used for the bundle verification process
+ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
+
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
+LABEL org.opencontainers.image.version="${ROUNDCUBEMAIL_VERSION}"
 
 # This should be done by the upstream images, but as long as they don't do it,
 # we rather use our own hands than suffer from outdated packages.
@@ -86,14 +96,6 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 
 COPY --chmod=0755 docker-entrypoint.sh /
-
-# Define Roundcubemail version
-# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
-# environment.
-ARG ROUNDCUBEMAIL_VERSION=1.7.1
-
-# Define the GPG key used for the bundle verification process
-ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,6 +1,16 @@
 FROM php:8.4-fpm AS root
+
+# Define Roundcubemail version
+# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
+# environment.
+ARG ROUNDCUBEMAIL_VERSION=1.7.1
+
+# Define the GPG key used for the bundle verification process
+ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
+
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
+LABEL org.opencontainers.image.version="${ROUNDCUBEMAIL_VERSION}"
 
 # This should be done by the upstream images, but as long as they don't do it,
 # we rather use our own hands than suffer from outdated packages.
@@ -99,14 +109,6 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 
 COPY --chmod=0755 docker-entrypoint.sh /
-
-# Define Roundcubemail version
-# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
-# environment.
-ARG ROUNDCUBEMAIL_VERSION=1.7.1
-
-# Define the GPG key used for the bundle verification process
-ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/templates/Dockerfile-alpine.templ
+++ b/templates/Dockerfile-alpine.templ
@@ -1,6 +1,16 @@
 FROM php:8.4-%%VARIANT%%3.21 AS root
+
+# Define Roundcubemail version
+# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
+# environment.
+ARG ROUNDCUBEMAIL_VERSION=%%VERSION%%
+
+# Define the GPG key used for the bundle verification process
+ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
+
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
+LABEL org.opencontainers.image.version="${ROUNDCUBEMAIL_VERSION}"
 
 # This should be done by the upstream images, but as long as they don't do it,
 # we rather use our own hands than suffer from outdated packages.
@@ -86,14 +96,6 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 
 COPY --chmod=0755 docker-entrypoint.sh /
-
-# Define Roundcubemail version
-# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
-# environment.
-ARG ROUNDCUBEMAIL_VERSION=%%VERSION%%
-
-# Define the GPG key used for the bundle verification process
-ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/templates/Dockerfile-debian.templ
+++ b/templates/Dockerfile-debian.templ
@@ -1,6 +1,16 @@
 FROM php:8.4-%%VARIANT%% AS root
+
+# Define Roundcubemail version
+# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
+# environment.
+ARG ROUNDCUBEMAIL_VERSION=%%VERSION%%
+
+# Define the GPG key used for the bundle verification process
+ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
+
 LABEL maintainer="Thomas Bruederli <thomas@roundcube.net>"
 LABEL org.opencontainers.image.source="https://github.com/roundcube/roundcubemail-docker"
+LABEL org.opencontainers.image.version="${ROUNDCUBEMAIL_VERSION}"
 
 # This should be done by the upstream images, but as long as they don't do it,
 # we rather use our own hands than suffer from outdated packages.
@@ -99,14 +109,6 @@ RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY php.ini /usr/local/etc/php/conf.d/roundcube-defaults.ini
 
 COPY --chmod=0755 docker-entrypoint.sh /
-
-# Define Roundcubemail version
-# Use an ARG to make it overwritable from a build argument and not leak into the container runtime
-# environment.
-ARG ROUNDCUBEMAIL_VERSION=%%VERSION%%
-
-# Define the GPG key used for the bundle verification process
-ARG ROUNDCUBEMAIL_KEYID="F3E4 C04B B3DB 5D42 15C4  5F7F 5AB2 BAA1 41C4 F7D5"
 
 # Download package and extract to web volume
 RUN set -ex; \

--- a/update.sh
+++ b/update.sh
@@ -2,18 +2,6 @@
 
 set -eu
 
-declare -A CMD=(
-	[apache]='apache2-foreground'
-	[fpm]='php-fpm'
-	[fpm-alpine]='php-fpm'
-)
-
-declare -A BASE=(
-	[apache]='debian'
-	[fpm]='debian'
-	[fpm-alpine]='alpine'
-)
-
 VERSION_STABLE="${1:-$(curl -fsS https://roundcube.net/VERSION.txt)}"
 VERSION_LTS="${2:-$(curl -fLsS https://raw.githubusercontent.com/roundcube/roundcube.github.com/refs/heads/master/_data/downloads.json | yq '.lts.packages[0].version')}"
 
@@ -25,17 +13,20 @@ fi
 #set -x
 echo "Generating files for stable version $VERSION_STABLE..."
 
-for variant in apache fpm fpm-alpine; do
+update_build_files_from_templates() {
+    variant="$1"
+    base="$2"
+    cmd="$3"
 	dir="$variant"
 	mkdir -p "$dir"
 
-	template="templates/Dockerfile-${BASE[$variant]}.templ"
+	template="templates/Dockerfile-${base}.templ"
 	cp templates/docker-entrypoint.sh "$dir/docker-entrypoint.sh"
 	cp templates/php.ini "$dir/php.ini"
 	sed -E -e '
 		s/%%VARIANT%%/'"$variant"'/;
 		s/%%VERSION%%/'"$VERSION_STABLE"'/;
-		s/%%CMD%%/'"${CMD[$variant]}"'/;
+		s/%%CMD%%/'"${cmd}"'/;
 	' $template | tr '¬' '\n' > "$dir/Dockerfile"
 
 	if [[ -f "$dir/nonroot-add.txt" ]]; then
@@ -45,7 +36,11 @@ for variant in apache fpm fpm-alpine; do
 	fi
 
 	echo "✓ Wrote $dir/Dockerfile"
-done
+}
+
+update_build_files_from_templates apache debian apache2-foreground
+update_build_files_from_templates fpm debian php-fpm
+update_build_files_from_templates fpm-alpine alpine php-fpm
 
 export VERSION_STABLE VERSION_LTS
 yq -i '.jobs.build-and-testvariants.strategy.matrix.version = [strenv(VERSION_STABLE), strenv(VERSION_LTS)]' .github/workflows/test.yml


### PR DESCRIPTION
We previously changed the ROUNDCUBEMAIL_VERSION environment variable into a build argument, so building images for different Roundcubemail versions got easier. But actually it's sometimes helpful to know which Roundcubemail version an image will serve (and people ask for it, see #443), so here it is back as a label.

Closes #443